### PR TITLE
chore: run make upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,19 +4,19 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
-attrs==21.4.0
+attrs==22.1.0
     # via -r requirements/base.in
-django==3.2.11
+django==3.2.15
     # via
     #   -r requirements/base.in
     #   django-model-utils
 django-model-utils==4.2.0
     # via -r requirements/base.in
-django-simple-history==3.0.0
+django-simple-history==3.1.1
     # via -r requirements/base.in
-pytz==2021.3
+pytz==2022.1
     # via django
 sqlparse==0.4.2
     # via django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.3
+coverage==6.4.2
     # via codecov
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -22,25 +22,23 @@ idna==3.3
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-requests==2.27.1
+requests==2.28.1
     # via codecov
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
     # via tox
-tox==3.24.5
+tox==3.25.1
     # via -r requirements/ci.in
-urllib3==1.26.8
+urllib3==1.26.11
     # via requests
-virtualenv==20.13.0
+virtualenv==20.16.2
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,36 +4,44 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.9.3
+astroid==2.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-bleach==4.1.0
+bleach==5.0.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-certifi==2021.10.8
+build==0.8.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-chardet==4.0.0
+cffi==1.15.1
+    # via
+    #   -r requirements/quality.txt
+    #   cryptography
+chardet==5.0.0
     # via diff-cover
-charset-normalizer==2.0.10
+charset-normalizer==2.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -41,50 +49,58 @@ click==8.0.3
     #   code-annotations
     #   edx-lint
     #   pip-tools
-click-log==0.3.2
+click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-colorama==0.4.4
+commonmark==0.9.1
     # via
     #   -r requirements/quality.txt
-    #   twine
-coverage[toml]==6.3
+    #   rich
+coverage[toml]==6.4.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-diff-cover==6.4.4
+cryptography==37.0.4
+    # via
+    #   -r requirements/quality.txt
+    #   secretstorage
+diff-cover==6.5.1
     # via -r requirements/dev.in
-distlib==0.3.4
+dill==0.3.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   pylint
+distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.11
+django==3.2.15
     # via
     #   -r requirements/quality.txt
     #   django-model-utils
     #   edx-i18n-tools
 django-model-utils==4.2.0
     # via -r requirements/quality.txt
-django-simple-history==3.0.0
+django-simple-history==3.1.1
     # via -r requirements/quality.txt
-docutils==0.18.1
+docutils==0.19
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-i18n-tools==0.8.1
+edx-i18n-tools==0.9.1
     # via -r requirements/dev.in
-edx-lint==5.2.1
+edx-lint==5.2.4
     # via -r requirements/quality.txt
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -94,7 +110,7 @@ idna==3.3
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==4.10.1
+importlib-metadata==4.12.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -107,12 +123,17 @@ isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jinja2==3.0.3
+jeepney==0.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
+    #   secretstorage
+jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-keyring==23.5.0
+keyring==23.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -120,38 +141,39 @@ lazy-object-proxy==1.7.1
     # via
     #   -r requirements/quality.txt
     #   astroid
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/quality.txt
     #   jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
 packaging==21.3
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
-    #   bleach
+    #   build
     #   pytest
     #   tox
-path==16.3.0
+path==16.4.0
     # via edx-i18n-tools
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
-    #   pip-tools
-pip-tools==6.4.0
+    #   build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.txt
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via
     #   -r requirements/quality.txt
     #   twine
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -172,16 +194,21 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via -r requirements/quality.txt
+pycparser==2.21
+    # via
+    #   -r requirements/quality.txt
+    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   -r requirements/quality.txt
     #   diff-cover
     #   readme-renderer
-pylint==2.12.2
+    #   rich
+pylint==2.14.5
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -192,7 +219,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -201,12 +228,13 @@ pylint-plugin-utils==0.7
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -215,11 +243,11 @@ pytest-cov==3.0.0
     # via -r requirements/quality.txt
 pytest-django==4.5.2
     # via -r requirements/quality.txt
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/quality.txt
     #   django
@@ -228,11 +256,11 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-readme-renderer==32.0
+readme-renderer==35.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.27.1
+requests==2.28.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -247,6 +275,14 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
+rich==12.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   twine
+secretstorage==3.3.2
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -254,7 +290,6 @@ six==1.16.0
     #   bleach
     #   edx-lint
     #   tox
-    #   virtualenv
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -263,7 +298,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -274,39 +309,41 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/ci.txt
-    #   -r requirements/quality.txt
-    #   pylint
-    #   pytest
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   build
     #   coverage
     #   pep517
-tox==3.24.5
+    #   pylint
+    #   pytest
+tomlkit==0.11.1
+    # via
+    #   -r requirements/quality.txt
+    #   pylint
+tox==3.25.1
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-tqdm==4.62.3
-    # via
-    #   -r requirements/quality.txt
-    #   twine
-twine==3.7.1
+twine==4.0.1
     # via -r requirements/quality.txt
-typing-extensions==4.0.1
+typing-extensions==4.3.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.8
+    #   rich
+urllib3==1.26.11
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.13.0
+    #   twine
+virtualenv==20.16.2
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -318,11 +355,11 @@ wheel==0.37.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.13.3
+wrapt==1.14.1
     # via
     #   -r requirements/quality.txt
     #   astroid
-zipp==3.7.0
+zipp==3.8.1
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,43 +6,43 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.9.1
+babel==2.10.3
     # via sphinx
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.1.0
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via -r requirements/test.txt
-coverage[toml]==6.3
+coverage[toml]==6.4.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-django==3.2.11
+django==3.2.15
     # via
     #   -r requirements/test.txt
     #   django-model-utils
 django-model-utils==4.2.0
     # via -r requirements/test.txt
-django-simple-history==3.0.0
+django-simple-history==3.1.1
     # via -r requirements/test.txt
-doc8==0.10.1
+doc8==1.0.0
     # via -r requirements/doc.in
-docutils==0.17.1
+docutils==0.19
     # via
     #   doc8
     #   readme-renderer
@@ -52,30 +52,29 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.10.1
+importlib-metadata==4.12.0
     # via sphinx
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/test.txt
     #   jinja2
 packaging==21.3
     # via
     #   -r requirements/test.txt
-    #   bleach
     #   pytest
     #   sphinx
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -87,16 +86,16 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pygments==2.11.2
+pygments==2.12.0
     # via
     #   doc8
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -105,11 +104,11 @@ pytest-cov==3.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/test.txt
     #   babel
@@ -118,11 +117,11 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==32.0
+readme-renderer==35.0
     # via -r requirements/doc.in
-requests==2.27.1
+requests==2.28.1
     # via sphinx
-restructuredtext-lint==1.3.2
+restructuredtext-lint==1.4.0
     # via doc8
 six==1.16.0
     # via
@@ -130,7 +129,7 @@ six==1.16.0
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.4.0
+sphinx==5.1.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -152,7 +151,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -161,17 +160,15 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-toml==0.10.2
-    # via
-    #   -r requirements/test.txt
-    #   pytest
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
-urllib3==1.26.8
+    #   doc8
+    #   pytest
+urllib3==1.26.11
     # via requests
 webencodings==0.5.1
     # via bleach
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
-click==8.0.3
+build==0.8.0
     # via pip-tools
-pep517==0.12.0
+click==8.1.3
     # via pip-tools
-pip-tools==6.4.0
+packaging==21.3
+    # via build
+pep517==0.13.0
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.in
-tomli==2.0.0
-    # via pep517
+pyparsing==3.0.9
+    # via packaging
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,57 +4,63 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.9.3
+astroid==2.11.7
     # via
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-bleach==4.1.0
+bleach==5.0.1
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.10
+cffi==1.15.1
+    # via cryptography
+charset-normalizer==2.1.0
     # via requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-lint
-click-log==0.3.2
+click-log==0.4.0
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-colorama==0.4.4
-    # via twine
-coverage[toml]==6.3
+commonmark==0.9.1
+    # via rich
+coverage[toml]==6.4.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-django==3.2.11
+cryptography==37.0.4
+    # via secretstorage
+dill==0.3.5.1
+    # via pylint
+django==3.2.15
     # via
     #   -r requirements/test.txt
     #   django-model-utils
 django-model-utils==4.2.0
     # via -r requirements/test.txt
-django-simple-history==3.0.0
+django-simple-history==3.1.1
     # via -r requirements/test.txt
-docutils==0.18.1
+docutils==0.19
     # via readme-renderer
-edx-lint==5.2.1
+edx-lint==5.2.4
     # via -r requirements/quality.in
 idna==3.3
     # via requests
-importlib-metadata==4.10.1
+importlib-metadata==4.12.0
     # via
     #   keyring
     #   twine
@@ -66,32 +72,35 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==3.0.3
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
+jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-keyring==23.5.0
+keyring==23.7.0
     # via twine
 lazy-object-proxy==1.7.1
     # via astroid
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/test.txt
     #   jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 packaging==21.3
     # via
     #   -r requirements/test.txt
-    #   bleach
     #   pytest
-pbr==5.8.0
+pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via
@@ -101,13 +110,17 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via -r requirements/quality.in
+pycparser==2.21
+    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pygments==2.11.2
-    # via readme-renderer
-pylint==2.12.2
+pygments==2.12.0
+    # via
+    #   readme-renderer
+    #   rich
+pylint==2.14.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -115,17 +128,17 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.3
     # via edx-lint
 pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -134,11 +147,11 @@ pytest-cov==3.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -146,9 +159,9 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==32.0
+readme-renderer==35.0
     # via twine
-requests==2.27.1
+requests==2.28.1
     # via
     #   requests-toolbelt
     #   twine
@@ -156,6 +169,10 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
+rich==12.5.1
+    # via twine
+secretstorage==3.3.2
+    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -166,7 +183,7 @@ sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -174,30 +191,30 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-toml==0.10.2
-    # via
-    #   -r requirements/test.txt
-    #   pylint
-    #   pytest
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
-tqdm==4.62.3
-    # via twine
-twine==3.7.1
+    #   pylint
+    #   pytest
+tomlkit==0.11.1
+    # via pylint
+twine==4.0.1
     # via -r requirements/quality.in
-typing-extensions==4.0.1
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.8
-    # via requests
+    #   rich
+urllib3==1.26.11
+    # via
+    #   requests
+    #   twine
 webencodings==0.5.1
     # via bleach
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,44 +4,44 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/base.txt
     #   pytest
-click==8.0.3
+click==8.1.3
     # via code-annotations
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==6.3
+coverage[toml]==6.4.2
     # via pytest-cov
     # via
     #   -r requirements/base.txt
     #   django-model-utils
 django-model-utils==4.2.0
     # via -r requirements/base.txt
-django-simple-history==3.0.0
+django-simple-history==3.1.1
     # via -r requirements/base.txt
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.3
+jinja2==3.1.2
     # via code-annotations
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 packaging==21.3
     # via pytest
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
 pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -49,9 +49,9 @@ pytest-cov==3.0.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via code-annotations
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -61,11 +61,11 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.5.0
+stevedore==4.0.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-toml==0.10.2
-    # via pytest
-tomli==2.0.0
-    # via coverage
+tomli==2.0.1
+    # via
+    #   coverage
+    #   pytest


### PR DESCRIPTION
The version of pip-tools that was previously pinned breaks
with the latest version of pip.
