### PR TITLE
Remove dependencies, add import-linting

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,45 @@
+# openedx_learning is intended to be a library of apps used across multiple
+# projects, and we want to ensure certain dependency relationships. Please
+# think through any changes you make to this file carefully, and don't just
+# casually modify these linting rules to "fix the build".
+[importlinter]
+root_package = openedx_learning
+
+# This is the most basic layering for openedx_learning.
+#
+# The "lib" package is meant for low level utilities, field definitions, and the
+# like, so it's at the bottom layer.
+#
+# The "core" apps are meant to be the heart of our system, with foundational
+# data models and plugin interfaces. It can rely on "lib" utilities.
+#
+# The "contrib" apps are meant to be apps that could easily be created outside
+# of openedx_learning in a separate repository, but are bundled here because
+# we think they'll be generally useful. These apps may call into "core" or "lib"
+# apps, but not the other way around. The "core" apps should *never* import from
+# "contrib".
+[importlinter:contract:openedx_learning_layering]
+name = Lib / Core / Contrib Layering
+type = layers
+layers=
+    openedx_learning.contrib
+    openedx_learning.core
+    openedx_learning.lib
+
+# This is layering within our Core apps.
+#
+# The lowest layer is "publishing", which holds the basic primitives needed to
+# create LearningContexts and versioning.
+#
+# One layer above that is "itemstore" which stores single Items (e.g. Problem,
+# Video).
+#
+# Above "itemstore" are apps that can compose those Items into more interesting
+# structures (like Units).
+[importlinter:contract:core_apps_layering]
+name = Core App Dependency Layering
+type = layers
+layers=
+    openedx_learning.core.composition
+    openedx_learning.core.itemstore
+    openedx_learning.core.publishing

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,8 +3,4 @@
 
 Django<4.0                # Web application framework
 
-## Model utilities...
-django-model-utils        # Provides TimeStampedModel abstract base class
-django-simple-history     # For historical records of our models.
-
 attrs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,12 +9,6 @@ asgiref==3.5.2
 attrs==22.1.0
     # via -r requirements/base.in
 django==3.2.15
-    # via
-    #   -r requirements/base.in
-    #   django-model-utils
-django-model-utils==4.2.0
-    # via -r requirements/base.in
-django-simple-history==3.1.1
     # via -r requirements/base.in
 pytz==2022.1
     # via django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,3 +3,4 @@
 
 codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
+import-linter             # Track our internal dependencies

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,9 +8,11 @@ certifi==2022.6.15
     # via requests
 charset-normalizer==2.1.0
     # via requests
+click==8.1.3
+    # via import-linter
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.4.2
+coverage==6.4.3
     # via codecov
 distlib==0.3.5
     # via virtualenv
@@ -18,8 +20,14 @@ filelock==3.7.1
     # via
     #   tox
     #   virtualenv
+grimp==1.2.3
+    # via import-linter
 idna==3.3
     # via requests
+import-linter==1.2.7
+    # via -r requirements/ci.in
+networkx==2.8.5
+    # via grimp
 packaging==21.3
     # via tox
 platformdirs==2.5.2
@@ -40,5 +48,5 @@ tox==3.25.1
     # via -r requirements/ci.in
 urllib3==1.26.11
     # via requests
-virtualenv==20.16.2
+virtualenv==20.16.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,12 +80,7 @@ distlib==0.3.5
 django==3.2.15
     # via
     #   -r requirements/quality.txt
-    #   django-model-utils
     #   edx-i18n-tools
-django-model-utils==4.2.0
-    # via -r requirements/quality.txt
-django-simple-history==3.1.1
-    # via -r requirements/quality.txt
 docutils==0.19
     # via
     #   -r requirements/quality.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,10 +30,6 @@ certifi==2022.6.15
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-cffi==1.15.1
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==5.0.0
     # via diff-cover
 charset-normalizer==2.1.0
@@ -43,11 +39,13 @@ charset-normalizer==2.1.0
     #   requests
 click==8.1.3
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   click-log
     #   code-annotations
     #   edx-lint
+    #   import-linter
     #   pip-tools
 click-log==0.4.0
     # via
@@ -63,16 +61,12 @@ commonmark==0.9.1
     # via
     #   -r requirements/quality.txt
     #   rich
-coverage[toml]==6.4.2
+coverage[toml]==6.4.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-cryptography==37.0.4
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 diff-cover==6.5.1
     # via -r requirements/dev.in
 dill==0.3.5.1
@@ -105,11 +99,17 @@ filelock==3.7.1
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
+grimp==1.2.3
+    # via
+    #   -r requirements/ci.txt
+    #   import-linter
 idna==3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
+import-linter==1.2.7
+    # via -r requirements/ci.txt
 importlib-metadata==4.12.0
     # via
     #   -r requirements/quality.txt
@@ -123,17 +123,12 @@ isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-keyring==23.7.0
+keyring==23.8.1
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -149,6 +144,10 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
+networkx==2.8.5
+    # via
+    #   -r requirements/ci.txt
+    #   grimp
 packaging==21.3
     # via
     #   -r requirements/ci.txt
@@ -194,12 +193,8 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   pytest
     #   tox
-pycodestyle==2.9.0
+pycodestyle==2.9.1
     # via -r requirements/quality.txt
-pycparser==2.21
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.12.0
@@ -256,7 +251,7 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-readme-renderer==35.0
+readme-renderer==36.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -279,10 +274,6 @@ rich==12.5.1
     # via
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.2
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -343,7 +334,7 @@ urllib3==1.26.11
     #   -r requirements/quality.txt
     #   requests
     #   twine
-virtualenv==20.16.2
+virtualenv==20.16.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,7 +28,7 @@ click==8.1.3
     #   code-annotations
 code-annotations==1.3.0
     # via -r requirements/test.txt
-coverage[toml]==6.4.2
+coverage[toml]==6.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -117,7 +117,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==35.0
+readme-renderer==36.0
     # via -r requirements/doc.in
 requests==2.28.1
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -33,12 +33,6 @@ coverage[toml]==6.4.3
     #   -r requirements/test.txt
     #   pytest-cov
 django==3.2.15
-    # via
-    #   -r requirements/test.txt
-    #   django-model-utils
-django-model-utils==4.2.0
-    # via -r requirements/test.txt
-django-simple-history==3.1.1
     # via -r requirements/test.txt
 doc8==1.0.0
     # via -r requirements/doc.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -43,12 +43,6 @@ coverage[toml]==6.4.3
 dill==0.3.5.1
     # via pylint
 django==3.2.15
-    # via
-    #   -r requirements/test.txt
-    #   django-model-utils
-django-model-utils==4.2.0
-    # via -r requirements/test.txt
-django-simple-history==3.1.1
     # via -r requirements/test.txt
 docutils==0.19
     # via readme-renderer

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -20,8 +20,6 @@ bleach==5.0.1
     # via readme-renderer
 certifi==2022.6.15
     # via requests
-cffi==1.15.1
-    # via cryptography
 charset-normalizer==2.1.0
     # via requests
 click==8.1.3
@@ -38,12 +36,10 @@ code-annotations==1.3.0
     #   edx-lint
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.4.2
+coverage[toml]==6.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==37.0.4
-    # via secretstorage
 dill==0.3.5.1
     # via pylint
 django==3.2.15
@@ -72,15 +68,11 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-keyring==23.7.0
+keyring==23.8.1
     # via twine
 lazy-object-proxy==1.7.1
     # via astroid
@@ -110,10 +102,8 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycodestyle==2.9.0
+pycodestyle==2.9.1
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.12.0
@@ -159,7 +149,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-readme-renderer==35.0
+readme-renderer==36.0
     # via twine
 requests==2.28.1
     # via
@@ -171,8 +161,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.5.1
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ click==8.1.3
     # via code-annotations
 code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==6.4.2
+coverage[toml]==6.4.3
     # via pytest-cov
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,12 +18,6 @@ code-annotations==1.3.0
     # via -r requirements/test.in
 coverage[toml]==6.4.3
     # via pytest-cov
-    # via
-    #   -r requirements/base.txt
-    #   django-model-utils
-django-model-utils==4.2.0
-    # via -r requirements/base.txt
-django-simple-history==3.1.1
     # via -r requirements/base.txt
 iniconfig==1.1.1
     # via pytest


### PR DESCRIPTION
I've combined two commits into one PR because they both update dependencies:

```
feat: add import linting

import-linter is meant to help us keep our internal dependencies clear,
and prevent accidental circular dependencies or other unwanted code
relationships.

You can run the linter with the command: lint-imports
```

```
chore: remove unnecessary dependencies

The standards cookiecutter for Open edX projects includes
django-model-utils and django-simple-history. This repo doesn't really
need them because:

1. django-model-utils is only really used for TimeStampedModel, and that
   is just to get consistent naming of created/modified fields. We can
   do that without taking on the entire dependency.
2. django-simple-history offers a convenient way to make a history
   table, and we do have versioned models in many cases. However, our
   versioning needs are very explicit and particular, and they go beyond
   the simple changelog-style history that this library provides.

In general, we want to keep the dependencies in this repo as small as
possible, to make it easy to use in different projects.
```
