### PR TITLE
build: publish openedx-learning to pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]  # Add macos-latest later?
         python-version: ['3.8']
-        toxenv: ["py38-django32", "py38-django42"]
+        toxenv: ["py38-django32", "py38-django42", "package"]
         # We're only testing against MySQL 8 right now because 5.7 is
         # incompatible with Djagno 4.2. We'd have to make the tox.ini file more
         # complicated than it's worth given the short expected shelf-life of

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,30 @@
+name: Publish package to PyPI
+
+on:
+  push:
+    tags: 
+      - '*'
+
+jobs:
+  push:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pip
+        run: pip install -r requirements/pip.txt
+
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -24,7 +24,7 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/tox.ini
+++ b/tox.ini
@@ -88,3 +88,11 @@ deps =
     -r{toxinidir}/requirements/test.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
+
+[testenv:package]
+deps =
+    build
+    twine
+commands =
+    python -m build
+    twine check dist/*


### PR DESCRIPTION
Creates pypi-publish.yml using the [procedure recommended by edx-platform](https://github.com/openedx/edx-platform/blob/83f54aeebe5a729935fe7de10c56bccd63c1b228/requirements/edx/github.in#L15-L19).