### PR TITLE
docs: ADR for pagination and repr of single taxonomy view api [FC-0030]

### DIFF
--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -7,8 +7,8 @@ Context
 
 This view returns tags of a closed taxonomy (for MVP has not been implemented yet
 for open taxonomies). It is necessary to make a decision about what structure the tags are going 
-to have and how the pagination is going to work. It was taken into account that a taxonomy can
-have a large number of tags and are mostly represented as trees.
+to have, how the pagination is going to work and how will the search for tags be implemented.
+It was taken into account that a taxonomy can have a large number of tags and are mostly represented as trees.
 
 **Branch:** Is the representation of a root Tag and all its children up to the leaves.
 
@@ -82,6 +82,17 @@ Children do not affect pagination in any way.
   the branch has hundreds of children, and they would still all be brought.
 
 
+Search tags
+~~~~~~~~~~~~
+
+Support tag search on the backend. Return a subset of matching tags in the format proposed
+in this document.
+
+**Pros**
+
+- It is the most scalable way.
+
+
 Rejected Options
 -----------------
 
@@ -131,3 +142,15 @@ Ex. If the ``page_size`` is 100, when fetching the first root tag, which has 10 
 - All branches are variable in size, therefore a variable number of root tags
   would be returned. This would cause interfaces between taxonomies to be inconsistent
   in the number of root tags shown.
+
+
+Search on frontend
+~~~~~~~~~~~~~~~~~~
+
+We constrain the number of tags allowed in a taxonomy for MVP, so that the API 
+can return all the tags in one page. So we can perform the tag search on the frontend.
+
+**Cons:**
+
+- It is not scalable
+- Sets limits of tags that can be created in the taxonomy

--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -14,10 +14,21 @@ It was taken into account that a taxonomy can have a large number of tags and ar
 
 For the decisions, the following use cases were taken into account:
 
-- List of root tags that can be expanded to show children tags.
-    - This list can be sorted alphabetically: A-Z (default) and Z-A
-- The user can expand all root tags.
-- The user can search for tags.
+- As a taxonomy administrator, I want to see all the tags available for use with a closed taxonomy,
+  so that I can see the taxonomy's structure in the management interface.
+     - As a taxonomy administrator, I want to see the available tags as a lits of root tags
+       that can be expanded to show children tags.
+     - As a taxonomy administrator, I want to sort the list of root tags alphabetically: A-Z (default) and Z-A.
+     - As a taxonomy administrator, I want to expand all root tags to see all children tags.
+     - As a taxonomy administrator, I want to search for tags, so I can find root and children tags more easily.
+- (TODO: discuss with UX) As a course author, when I am editing the tags of a component, I want to see all the tags available
+  from a particular taxonomy that I can use.
+
+Excluded use cases:
+
+- As a content author, when searching/filtering a course/library, I want to see which tags are applied to the content
+  and use them to refine my search. - This is excluded from this API's use case because this is automatically handled
+  by elasticsearch/opensearch.
 
 
 Decision

--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -1,0 +1,126 @@
+13. Single taxonomy view API
+=====================================
+
+
+Context
+--------
+
+This view returns tags of a closed taxonomy (for MVP has not been implemented yet
+for open taxonomies). It is necessary to make a decision about what structure the tags are going 
+to have and how the pagination is going to work. It was taken into account that a taxonomy can
+have a large number of tags and are mostly represented as trees.
+
+**Branch:** Is the representation of a root Tag and all its children up to the leaves.
+
+
+Decision
+---------
+
+
+Tag representation
+~~~~~~~~
+
+Return a list of root tags and within each one have the list of children tags. Each root would have
+its entire branch. The list of root tags will be ordered alphabetically as is each listing at each level of the tree.
+
+{
+    "count": 100,
+    "tags": [
+        {
+            "id": "tag_1",
+            "value": "Tag 1",
+            "taxonomy_id": "1",
+            "sub_tags": [
+                {
+                    "id": "tag_2",
+                    "value": "Tag 2",
+                    "taxonomy_id": "1",
+                    "sub_tags": [
+                        (....)
+                    ]
+                },
+                (....)
+            ]
+        },
+        (....)
+    ]
+}
+
+
+**Pros:**
+
+- The edX's interfaces show the tags in the form of a tree.
+- The frontend needs no further processing as it is in a displayable format.
+- It is kept as a simple implementation.
+
+**Cons:**
+
+- More implementation on the API side.
+
+
+Pagination
+~~~~~~~~~~~
+
+Apply the pagination only in the root tags and bring the entire branch of each root.
+Children do not affect pagination in any way.
+
+**Pros**
+
+- It is the simplest way.
+
+**Cons**
+
+- The children would not have pagination, in the long run there may be cases in which
+  the branch has hundreds of children, and they would still all be brought.
+
+
+Rejected Options
+-----------------
+
+
+Render as a simple list of tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Return a simple list of tags, regardless of whether it is root or leaf.
+
+**Pros:**
+
+- It is simple and does not need further implementation and processing in the API.
+
+**Cons:**
+
+- It is more work to re-process all that list in the frontend to know who it is
+whose father.
+- In no edX's interface is it used this way and it would be a very specific use case.
+- Pagination would be more complicated to perform.
+
+
+
+Get the branch in another call
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+Get the root tags in one call and all children tags of a branch in another call.
+This second function is called when the user expands the parent tag.
+
+**Cons:**
+
+- In the UI there is the functionality *Expand all*, another view would have to 
+  be made to handle this functionality in a scalable way.
+- A user could make many calls; every time a parent is opened.
+
+
+
+Add the children to the pagination
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ex. If the ``page_size`` is 100, when fetching the first root tag, which has 10 children tags, 
+11 tags are counted for the total and there would be reamin 89 tags to be obtained.
+
+**Cons:**
+
+- If there is a branch with a number of tags that exceeds ``page_size``, 
+  it would only return that branch.
+- All branches are variable in size, therefore a variable number of root tags
+  would be returned. This would cause interfaces between taxonomies to be inconsistent
+  in the number of root tags shown.

--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -56,7 +56,7 @@ In both cases the results are paginated. In addition to the common pagination me
 - Total number of pages.
 - Total number of root/children tags.
 - Range index of current page, Ex. Page 1: 1-12, Page 2: 13-24.
-- Total number of children of each root tag.
+- Total number of children of each tag.
 
 The pagination of root tags and child tags are independent.
 In order to be able to fulfill the functionality of "Expand-all" in a scalable way,

--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -12,6 +12,13 @@ have a large number of tags and are mostly represented as trees.
 
 **Branch:** Is the representation of a root Tag and all its children up to the leaves.
 
+For the decisions, the following use cases were taken into account:
+
+- List of root tags that can be expanded to show children tags.
+    - This list can be sorted alphabetically: A-Z (default) and Z-A
+- The user can expand all root tags.
+- The user can search for tags.
+
 
 Decision
 ---------
@@ -21,7 +28,8 @@ Tag representation
 ~~~~~~~~
 
 Return a list of root tags and within each one have the list of children tags. Each root would have
-its entire branch. The list of root tags will be ordered alphabetically as is each listing at each level of the tree.
+its entire branch. The list of root tags will be ordered alphabetically as is each listing
+at each level of the tree. This order can only be reversed in the root tag listing.
 
 {
     "count": 100,
@@ -89,8 +97,7 @@ Return a simple list of tags, regardless of whether it is root or leaf.
 
 **Cons:**
 
-- It is more work to re-process all that list in the frontend to know who it is
-whose father.
+- It is more work to re-process all that list in the frontend to know who it is whose father.
 - In no edX's interface is it used this way and it would be a very specific use case.
 - Pagination would be more complicated to perform.
 

--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -1,28 +1,32 @@
 13. Single taxonomy view API
 =====================================
 
-
 Context
 --------
 
 This view returns tags of a closed taxonomy (for MVP has not been implemented yet
 for open taxonomies). It is necessary to make a decision about what structure the tags are going 
 to have, how the pagination is going to work and how will the search for tags be implemented.
-It was taken into account that a taxonomy can have a large number of tags and are mostly represented as trees.
+It was taken into account that taxonomies commonly have the following characteristics:
 
-**Branch:** Is the representation of a root Tag and all its children up to the leaves.
+- It have few root tags.
+- It have a very large number of children for each tag.
+- It is mostly represented as trees on frontend.
 
 For the decisions, the following use cases were taken into account:
 
 - As a taxonomy administrator, I want to see all the tags available for use with a closed taxonomy,
   so that I can see the taxonomy's structure in the management interface.
-     - As a taxonomy administrator, I want to see the available tags as a lits of root tags
-       that can be expanded to show children tags.
-     - As a taxonomy administrator, I want to sort the list of root tags alphabetically: A-Z (default) and Z-A.
-     - As a taxonomy administrator, I want to expand all root tags to see all children tags.
-     - As a taxonomy administrator, I want to search for tags, so I can find root and children tags more easily.
-- (TODO: discuss with UX) As a course author, when I am editing the tags of a component, I want to see all the tags available
+    - As a taxonomy administrator, I want to see the available tags as a lits of root tags
+      that can be expanded to show children tags.
+    - As a taxonomy administrator, I want to sort the list of root tags alphabetically: A-Z (default) and Z-A.
+    - As a taxonomy administrator, I want to expand all root tags to see all children tags.
+    - As a taxonomy administrator, I want to search for tags, so I can find root and children tags more easily.
+- As a course author, when I am editing the tags of a component, I want to see all the tags available
   from a particular taxonomy that I can use.
+    - As a course author, I want to see the available tags as a lits of root tags
+      that can be expanded to show children tags.
+    - As a course author, I want to search for tags, so I can find root and children tags more easily.
 
 Excluded use cases:
 
@@ -34,15 +38,48 @@ Excluded use cases:
 Decision
 ---------
 
+Views & Pagination
+~~~~~~~~~~~~~~~~~~~
+
+Make two different views:
+
+- **get_root_tags():** It is the first call to obtain the parent tags of the taxonomy.
+  It has pagination. In addition to the common pagination metadata, it is necessary to return:
+    - Total number of pages.
+    - Total number of root tags.
+    - Range index of current page, Ex. Page 1: 1-12, Page 2: 13-24
+    - Total number of children of each root tag.
+- **get_children_tags():** Called each time the user expands a parent tag to see its children.
+  It has pagination. In addition to the common pagination metadata, it is necessary to return:
+    - Total number of children of each tag.
+
+As described above, the pagination of root tags and child tags are independent.
+In order to be able to fulfill the functionality of "Expand-all" in a scalable way,
+the following has been agreed:
+
+- Create a ``TAGS_THRESHOLD`` (default: 1000).
+- If ``taxonomy.tags.count < TAGS_THRESHOLD``, then ``get_root_tags`` will return all tags on the taxonomy,
+  roots and children.
+- Otherwise, ``get_root_tags`` will only return root tags, and it will be necessary
+  to use ``get_children_tags`` to return children. Also the "Expand-all" functionality will be disabled. 
+
+**Pros**
+
+- It is the simplest way.
+- Paging both root tags and children mitigates the huge number of tags that can be.
+
 
 Tag representation
-~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
-Return a list of root tags and within each one have the list of children tags. Each root would have
-its entire branch. The list of root tags will be ordered alphabetically as is each listing
-at each level of the tree. This order can only be reversed in the root tag listing.
+Return a list of root tags and within a link to obtain the children tags
+or the complete list of children tags depending of ``TAGS_THRESHOLD`` (see Views & Pagination). 
+The list of root tags will be ordered alphabetically. If it has child tags, they must also
+be ordered alphabetically.
 
-{
+**(taxonomy.tags.count < TAGS_THRESHOLD)**::
+
+  {
     "count": 100,
     "tags": [
         {
@@ -60,10 +97,23 @@ at each level of the tree. This order can only be reversed in the root tag listi
                 },
                 (....)
             ]
+  }
+
+
+**Otherwise**::
+
+  {
+    "count": 100,
+    "tags": [
+        {
+            "id": "tag_1",
+            "value": "Tag 1",
+            "taxonomy_id": "1",
+            "sub_tags_link": "http//api-call-to-get-children.com"
         },
         (....)
     ]
-}
+  }
 
 
 **Pros:**
@@ -71,26 +121,6 @@ at each level of the tree. This order can only be reversed in the root tag listi
 - The edX's interfaces show the tags in the form of a tree.
 - The frontend needs no further processing as it is in a displayable format.
 - It is kept as a simple implementation.
-
-**Cons:**
-
-- More implementation on the API side.
-
-
-Pagination
-~~~~~~~~~~~
-
-Apply the pagination only in the root tags and bring the entire branch of each root.
-Children do not affect pagination in any way.
-
-**Pros**
-
-- It is the simplest way.
-
-**Cons**
-
-- The children would not have pagination, in the long run there may be cases in which
-  the branch has hundreds of children, and they would still all be brought.
 
 
 Search tags
@@ -124,24 +154,8 @@ Return a simple list of tags, regardless of whether it is root or leaf.
 - Pagination would be more complicated to perform.
 
 
-
-Get the branch in another call
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-Get the root tags in one call and all children tags of a branch in another call.
-This second function is called when the user expands the parent tag.
-
-**Cons:**
-
-- In the UI there is the functionality *Expand all*, another view would have to 
-  be made to handle this functionality in a scalable way.
-- A user could make many calls; every time a parent is opened.
-
-
-
-Add the children to the pagination
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Add the children to the root pagination
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Ex. If the ``page_size`` is 100, when fetching the first root tag, which has 10 children tags, 
 11 tags are counted for the total and there would be reamin 89 tags to be obtained.
@@ -163,5 +177,5 @@ can return all the tags in one page. So we can perform the tag search on the fro
 
 **Cons:**
 
-- It is not scalable
-- Sets limits of tags that can be created in the taxonomy
+- It is not scalable.
+- Sets limits of tags that can be created in the taxonomy.

--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -68,16 +68,31 @@ the following has been agreed:
 - It is the simplest way.
 - Paging both root tags and children mitigates the huge number of tags that can be.
 
+Search tags
+~~~~~~~~~~~~
+
+Support tag search on the backend. Return a subset of matching tags.
+We will use the same views to perform a search with the same logic:
+
+- **get_root_tags(search: str)**
+- **get_children_tags(search: str)**
+
+For the search ``SEARCH_TAGS_THRESHOLD`` will be used. (It is recommended that it be 20 percent of ``TAGS_THRESHOLD``).
+It will work in the same way of ``TAGS_THRESHOLD`` (see Views & Pagination)
+
+**Pros**
+
+- It is the most scalable way.
 
 Tag representation
 ~~~~~~~~~~~~~~~~~~~
 
 Return a list of root tags and within a link to obtain the children tags
-or the complete list of children tags depending of ``TAGS_THRESHOLD`` (see Views & Pagination). 
+or the complete list of children tags depending of ``TAGS_THRESHOLD`` or ``SEARCH_TAGS_THRESHOLD``. 
 The list of root tags will be ordered alphabetically. If it has child tags, they must also
 be ordered alphabetically.
 
-**(taxonomy.tags.count < TAGS_THRESHOLD)**::
+**(taxonomy.tags.count < *_THRESHOLD)**::
 
   {
     "count": 100,
@@ -121,17 +136,6 @@ be ordered alphabetically.
 - The edX's interfaces show the tags in the form of a tree.
 - The frontend needs no further processing as it is in a displayable format.
 - It is kept as a simple implementation.
-
-
-Search tags
-~~~~~~~~~~~~
-
-Support tag search on the backend. Return a subset of matching tags in the format proposed
-in this document.
-
-**Pros**
-
-- It is the most scalable way.
 
 
 Rejected Options


### PR DESCRIPTION
This PR adds an ADR to define the representation of the tags and the pagination in the single taxonomy view api

Reference issue: https://github.com/openedx/modular-learning/issues/75
