### PR TITLE
Remove a comment copy-pasta

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,5 +11,4 @@ files =
     tests
 
 [mypy.plugins.django-stubs]
-# content_staging only works with CMS; others work with either, so we run mypy with CMS settings.
 django_settings_module = "projects.dev"


### PR DESCRIPTION
Quick fix to remove a comment that I left in by accident after copy-pasting. It doesn't make any sense in the new context.