### PR TITLE
Single taxonomy view [FC-0030]

### DIFF
--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -83,9 +83,18 @@ We will use the same view to perform a search with the same logic:
 
 **get_matching_tags(parent_tag_id: str = None, search_term: str = None)**
 
-We can use ``search_term`` to perferom a search on root tags or children tags depending of ``parent_tag_id``.
+We can use ``search_term`` to perform a search on all taxonomy tags or children tags depending of ``parent_tag_id``.
+The result will be a pruned tree with the necessary tags to be able to reach the results from a root tag. 
+Ex. if in the result there may be a child tag of ``depth=2``, but the parents are not found in the result.
+In this case, it is necessary to add the parent and the parent of the parent (root tag) to be able to show
+the child tag that is in the result.
 
 For the search, ``SEARCH_TAGS_THRESHOLD`` will be used. (It is recommended that it be 20% of ``TAGS_THRESHOLD``).
+It will work in the following way:
+
+- If ``search_result.count() < SEARCH_TAGS_THRESHOLD``, then it will return all tags on the result tree without pagination.
+- Otherwise, it will return the roots of the result tree with pagination. Each root will have the entire pruned branch.
+
 It will work in the same way of ``TAGS_THRESHOLD`` (see Views & Pagination)
 
 **Pros**

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -79,6 +79,47 @@ def get_tags(taxonomy: Taxonomy) -> list[Tag]:
     return taxonomy.cast().get_tags()
 
 
+def get_root_tags(taxonomy: Taxonomy) -> list[Tag]:
+    """
+    Returns a list of the root tags for the given taxonomy.
+
+    Note that if the taxonomy allows free-text tags, then the returned list will be empty.
+    """
+    return list(taxonomy.cast().get_filtered_tags())
+
+
+def search_tags(taxonomy: Taxonomy, search_term: str) -> list[Tag]:
+    """
+    Returns a list of all tags that contains `search_term` of the given taxonomy.
+
+    Note that if the taxonomy allows free-text tags, then the returned list will be empty.
+    """
+    return list(
+        taxonomy.cast().get_filtered_tags(
+            search_term=search_term,
+            search_in_all=True,
+        )
+    )
+
+
+def get_children_tags(
+    taxonomy: Taxonomy,
+    parent_tag_id: int,
+    search_term: str | None = None,
+) -> list[Tag]:
+    """
+    Returns a list of children tags for the given parent tag.
+
+    Note that if the taxonomy allows free-text tags, then the returned list will be empty.
+    """
+    return list(
+        taxonomy.cast().get_filtered_tags(
+            parent_tag_id=parent_tag_id,
+            search_term=search_term,
+        )
+    )
+
+
 def resync_object_tags(object_tags: QuerySet | None = None) -> int:
     """
     Reconciles ObjectTag entries with any changes made to their associated taxonomies and tags.
@@ -98,8 +139,7 @@ def resync_object_tags(object_tags: QuerySet | None = None) -> int:
 
 
 def get_object_tags(
-    object_id: str,
-    taxonomy_id: str | None = None
+    object_id: str, taxonomy_id: str | None = None
 ) -> QuerySet[ObjectTag]:
     """
     Returns a Queryset of object tags for a given object.
@@ -124,10 +164,8 @@ def delete_object_tags(object_id: str):
     """
     Delete all ObjectTag entries for a given object.
     """
-    tags = (
-        ObjectTag.objects.filter(
-            object_id=object_id,
-        )
+    tags = ObjectTag.objects.filter(
+        object_id=object_id,
     )
 
     tags.delete()

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -16,6 +16,7 @@ class TagItem:
     """
     Tag representation on the tag import plan
     """
+
     id: str
     value: str
     index: int | None = 0

--- a/openedx_tagging/core/tagging/import_export/parsers.py
+++ b/openedx_tagging/core/tagging/import_export/parsers.py
@@ -103,7 +103,9 @@ class Parser:
         raise NotImplementedError
 
     @classmethod
-    def _parse_tags(cls, tags_data: list[dict]) -> tuple[list[TagItem], list[TagParserError]]:
+    def _parse_tags(
+        cls, tags_data: list[dict]
+    ) -> tuple[list[TagItem], list[TagParserError]]:
         """
         Validate the required fields of each tag.
 

--- a/openedx_tagging/core/tagging/migrations/0007_tag_import_task_log_null_fix.py
+++ b/openedx_tagging/core/tagging/migrations/0007_tag_import_task_log_null_fix.py
@@ -4,15 +4,16 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('oel_tagging', '0006_auto_20230802_1631'),
+        ("oel_tagging", "0006_auto_20230802_1631"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='tagimporttask',
-            name='log',
-            field=models.TextField(blank=True, default=None, help_text='Action execution logs'),
+            model_name="tagimporttask",
+            name="log",
+            field=models.TextField(
+                blank=True, default=None, help_text="Action execution logs"
+            ),
         ),
     ]

--- a/openedx_tagging/core/tagging/migrations/0008_taxonomy_description_not_null.py
+++ b/openedx_tagging/core/tagging/migrations/0008_taxonomy_description_not_null.py
@@ -6,16 +6,19 @@ import openedx_learning.lib.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('oel_tagging', '0007_tag_import_task_log_null_fix'),
+        ("oel_tagging", "0007_tag_import_task_log_null_fix"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='taxonomy',
-            name='description',
-            field=openedx_learning.lib.fields.MultiCollationTextField(blank=True, default='', help_text='Provides extra information for the user when applying tags from this taxonomy to an object.'),
+            model_name="taxonomy",
+            name="description",
+            field=openedx_learning.lib.fields.MultiCollationTextField(
+                blank=True,
+                default="",
+                help_text="Provides extra information for the user when applying tags from this taxonomy to an object.",
+            ),
             preserve_default=False,
         ),
     ]

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -268,7 +268,10 @@ class Taxonomy(models.Model):
         self._taxonomy_class = taxonomy._taxonomy_class
         return self
 
-    def get_tags(self, tag_set: models.QuerySet | None = None) -> list[Tag]:
+    def get_tags(
+        self,
+        tag_set: models.QuerySet[Tag] | None = None,
+    ) -> list[Tag]:
         """
         Returns a list of all Tags in the current taxonomy, from the root(s)
         down to TAXONOMY_MAX_DEPTH tags, in tree order.
@@ -289,6 +292,7 @@ class Taxonomy(models.Model):
             tag_set = self.tag_set.all()
 
         parents = None
+
         for depth in range(TAXONOMY_MAX_DEPTH):
             filtered_tags = tag_set.prefetch_related("parent")
             if parents is None:
@@ -309,6 +313,42 @@ class Taxonomy(models.Model):
             if not parents:
                 break
         return tags
+
+    def get_filtered_tags(
+        self,
+        tag_set: models.QuerySet[Tag] | None = None,
+        parent_tag_id: int | None = None,
+        search_term: str | None = None,
+        search_in_all: bool = False,
+    ) -> models.QuerySet[Tag]:
+        """
+        Returns a filtered QuerySet of tags.
+        By default returns the root tags of the given taxonomy
+
+        Use `parent_tag_id` to return the children of a tag.
+
+        Use `search_term` to filter the results by values that contains `search_term`.
+
+        Set `search_in_all` to True to make the search in all tags on the given taxonomy.
+
+        Note: This is mostly an 'internal' API and generally code outside of openedx_tagging
+        should use the APIs in openedx_tagging.api which in turn use this.
+        """
+        if tag_set is None:
+            tag_set = self.tag_set.all()
+
+        if self.allow_free_text:
+            return tag_set.none()
+
+        if not search_in_all:
+            # If not search in all taxonomy, then apply parent filter.
+            tag_set = tag_set.filter(parent=parent_tag_id)
+
+        if search_term:
+            # Apply search filter
+            tag_set = tag_set.filter(value__icontains=search_term)
+
+        return tag_set.order_by("value", "id")
 
     def validate_object_tag(
         self,
@@ -348,7 +388,9 @@ class Taxonomy(models.Model):
         Subclasses can override this method to perform their own taxonomy validation checks.
         """
         # Must be linked to this taxonomy
-        return (object_tag.taxonomy_id is not None) and object_tag.taxonomy_id == self.id
+        return (
+            object_tag.taxonomy_id is not None
+        ) and object_tag.taxonomy_id == self.id
 
     def _check_tag(
         self,
@@ -481,9 +523,11 @@ class Taxonomy(models.Model):
         # Fetch tags that the object already has to exclude them from the result
         excluded_tags: list[str] = []
         if object_id:
-            excluded_tags = list(self.objecttag_set.filter(object_id=object_id).values_list(
-                "_value", flat=True
-            ))
+            excluded_tags = list(
+                self.objecttag_set.filter(object_id=object_id).values_list(
+                    "_value", flat=True
+                )
+            )
         return (
             # Fetch object tags from this taxonomy whose value contains the search
             self.objecttag_set.filter(_value__icontains=search)

--- a/openedx_tagging/core/tagging/models/system_defined.py
+++ b/openedx_tagging/core/tagging/models/system_defined.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 
-from openedx_tagging.core.tagging.models.base import ObjectTag
+from openedx_tagging.core.tagging.models.base import ObjectTag, Tag
 
 from .base import ObjectTag, Tag, Taxonomy
 
@@ -241,13 +241,42 @@ class LanguageTaxonomy(SystemDefinedTaxonomy):
     class Meta:
         proxy = True
 
-    def get_tags(self, tag_set: models.QuerySet | None = None) -> list[Tag]:
+    def get_tags(
+        self,
+        tag_set: models.QuerySet[Tag] | None = None,
+    ) -> list[Tag]:
         """
         Returns a list of all the available Language Tags, annotated with ``depth`` = 0.
         """
         available_langs = self._get_available_languages()
         tag_set = self.tag_set.filter(external_id__in=available_langs)
         return super().get_tags(tag_set=tag_set)
+
+    def get_filtered_tags(
+        self,
+        tag_set: models.QuerySet[Tag] | None = None,
+        parent_tag_id: int | None = None,
+        search_term: str | None = None,
+        search_in_all: bool = False,
+    ) -> models.QuerySet[Tag]:
+        """
+        Returns a filtered QuerySet of available Language Tags.
+        By default returns all the available Language Tags.
+
+        `parent_tag_id` returns an empty result because all Language tags are root tags.
+
+        Use `search_term` to filter the results by values that contains `search_term`.
+        """
+        if parent_tag_id:
+            return self.tag_set.none()
+
+        available_langs = self._get_available_languages()
+        tag_set = self.tag_set.filter(external_id__in=available_langs)
+        return super().get_filtered_tags(
+            tag_set=tag_set,
+            search_term=search_term,
+            search_in_all=search_in_all,
+        )
 
     def _get_available_languages(cls) -> set[str]:
         """

--- a/openedx_tagging/core/tagging/rest_api/paginators.py
+++ b/openedx_tagging/core/tagging/rest_api/paginators.py
@@ -1,0 +1,29 @@
+from edx_rest_framework_extensions.paginators import DefaultPagination  # type: ignore[import]
+
+# From this point, the tags begin to be paginated
+TAGS_THRESHOLD = 1000
+
+# From this point, search tags begin to be paginated
+SEARCH_TAGS_THRESHOLD = 200
+
+
+class TagsPagination(DefaultPagination):
+    """
+    Custom pagination configuration for taxonomies
+    with a large number of tags. Used on the get tags API view.
+    """
+    page_size = 10
+    max_page_size = 300
+
+
+class DisabledTagsPagination(DefaultPagination):
+    """
+    Custom pagination configuration for taxonomies
+    with a small number of tags. Used on the get tags API view
+
+    This class allows to bring all the tags of the taxonomy.
+    It should be used if the number of tags within
+    the taxonomy does not exceed `TAGS_THRESHOLD`.
+    """
+    page_size = TAGS_THRESHOLD
+    max_page_size = TAGS_THRESHOLD + 1

--- a/openedx_tagging/core/tagging/rest_api/v1/permissions.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/permissions.py
@@ -1,7 +1,7 @@
 """
 Tagging permissions
 """
-
+import rules  # type: ignore[import]
 from rest_framework.permissions import DjangoObjectPermissions
 
 
@@ -27,3 +27,15 @@ class ObjectTagObjectPermissions(DjangoObjectPermissions):
         "PATCH": ["%(app_label)s.change_%(model_name)s"],
         "DELETE": ["%(app_label)s.delete_%(model_name)s"],
     }
+
+
+class TagListPermissions(DjangoObjectPermissions):
+    def has_permission(self, request, view):
+        if not request.user or (
+            not request.user.is_authenticated and self.authenticated_users_only
+        ):
+            return False
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return rules.has_perm("oel_tagging.list_tag", request.user, obj)

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -3,8 +3,9 @@ API Serializers for taxonomies
 """
 
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
-from openedx_tagging.core.tagging.models import ObjectTag, Taxonomy
+from openedx_tagging.core.tagging.models import ObjectTag, Tag, Taxonomy
 
 
 class TaxonomyListQueryParamsSerializer(serializers.Serializer):
@@ -70,4 +71,88 @@ class ObjectTagUpdateQueryParamsSerializer(serializers.Serializer):
     Serializer of the query params for the ObjectTag UPDATE view
     """
 
-    taxonomy = serializers.PrimaryKeyRelatedField(queryset=Taxonomy.objects.all(), required=True)
+    taxonomy = serializers.PrimaryKeyRelatedField(
+        queryset=Taxonomy.objects.all(), required=True
+    )
+
+
+class TagsSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Tags
+
+    Adds a link to get the sub tags
+    """
+
+    sub_tags_link = serializers.SerializerMethodField()
+    children_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Tag
+        fields = (
+            "id",
+            "value",
+            "taxonomy_id",
+            "parent_id",
+            "sub_tags_link",
+            "children_count",
+        )
+
+    def get_sub_tags_link(self, obj):
+        if obj.children.count():
+            query_params = f"?parent_tag_id={obj.id}"
+            url = (
+                reverse("oel_tagging:taxonomy-tags", args=[str(obj.taxonomy_id)])
+                + query_params
+            )
+            request = self.context.get("request")
+            return request.build_absolute_uri(url)
+
+    def get_children_count(self, obj):
+        return obj.children.count()
+
+
+class TagsWithSubTagsSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Tags.
+
+    Represents a tree with a list of sub tags
+    """
+
+    sub_tags = serializers.SerializerMethodField()
+    children_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Tag
+        fields = (
+            "id",
+            "value",
+            "taxonomy_id",
+            "sub_tags",
+            "children_count",
+        )
+
+    def get_sub_tags(self, obj):
+        serializer = TagsWithSubTagsSerializer(
+            obj.children.all().order_by("value", "id"),
+            many=True,
+            read_only=True,
+        )
+        return serializer.data
+
+    def get_children_count(self, obj):
+        return obj.children.count()
+
+
+class TagsForSearchSerializer(TagsWithSubTagsSerializer):
+    """
+    Serializer for Tags
+
+    Used to filter sub tags of a given tag
+    """
+
+    def get_sub_tags(self, obj):
+        serializer = TagsWithSubTagsSerializer(obj.sub_tags, many=True, read_only=True)
+        return serializer.data
+
+    def get_children_count(self, obj):
+        return len(obj.sub_tags)

--- a/openedx_tagging/core/tagging/rest_api/v1/urls.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/urls.py
@@ -11,4 +11,11 @@ router = DefaultRouter()
 router.register("taxonomies", views.TaxonomyView, basename="taxonomy")
 router.register("object_tags", views.ObjectTagView, basename="object_tag")
 
-urlpatterns = [path("", include(router.urls))]
+urlpatterns = [
+    path("", include(router.urls)),
+    path(
+        "taxonomies/<str:pk>/tags/",
+        views.TaxonomyTagsView.as_view(),
+        name="taxonomy-tags",
+    ),
+]

--- a/openedx_tagging/core/tagging/rules.py
+++ b/openedx_tagging/core/tagging/rules.py
@@ -12,7 +12,9 @@ from attrs import define
 
 from .models import Tag, Taxonomy
 
-UserType = Union[django.contrib.auth.models.User, django.contrib.auth.models.AnonymousUser]
+UserType = Union[
+    django.contrib.auth.models.User, django.contrib.auth.models.AnonymousUser
+]
 
 
 # Global staff are taxonomy admins.
@@ -74,7 +76,9 @@ def can_change_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
 
 
 @rules.predicate
-def can_change_object_tag(user: UserType, perm_obj: ChangeObjectTagPermissionItem | None = None) -> bool:
+def can_change_object_tag(
+    user: UserType, perm_obj: ChangeObjectTagPermissionItem | None = None
+) -> bool:
     """
     Checks if the user has permissions to create or modify tags on the given taxonomy and object_id.
     """
@@ -84,7 +88,9 @@ def can_change_object_tag(user: UserType, perm_obj: ChangeObjectTagPermissionIte
         return True
 
     # Checks the permission for the taxonomy
-    taxonomy_perm = user.has_perm("oel_tagging.change_objecttag_taxonomy", perm_obj.taxonomy)
+    taxonomy_perm = user.has_perm(
+        "oel_tagging.change_objecttag_taxonomy", perm_obj.taxonomy
+    )
     if not taxonomy_perm:
         return False
 
@@ -109,6 +115,7 @@ rules.add_perm("oel_tagging.add_tag", can_change_tag)
 rules.add_perm("oel_tagging.change_tag", can_change_tag)
 rules.add_perm("oel_tagging.delete_tag", is_taxonomy_admin)
 rules.add_perm("oel_tagging.view_tag", rules.always_allow)
+rules.add_perm("oel_tagging.list_tag", can_view_taxonomy)
 
 # ObjectTag
 rules.add_perm("oel_tagging.add_objecttag", can_change_object_tag)

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -14,11 +14,13 @@ from rest_framework.test import APITestCase
 
 from openedx_tagging.core.tagging.models import ObjectTag, Tag, Taxonomy
 from openedx_tagging.core.tagging.models.system_defined import SystemDefinedTaxonomy
+from openedx_tagging.core.tagging.rest_api.paginators import TagsPagination
 
 User = get_user_model()
 
 TAXONOMY_LIST_URL = "/tagging/rest_api/v1/taxonomies/"
 TAXONOMY_DETAIL_URL = "/tagging/rest_api/v1/taxonomies/{pk}/"
+TAXONOMY_TAGS_URL = "/tagging/rest_api/v1/taxonomies/{pk}/tags/"
 
 
 OBJECT_TAGS_RETRIEVE_URL = "/tagging/rest_api/v1/object_tags/{object_id}/"
@@ -28,8 +30,8 @@ LANGUAGE_TAXONOMY_ID = -1
 
 
 def check_taxonomy(
-    data: dict,
-    id,  # pylint: disable=redefined-builtin
+    data,
+    taxonomy_id,
     name,
     description="",
     enabled=True,
@@ -40,9 +42,9 @@ def check_taxonomy(
     visible_to_authors=True,
 ):
     """
-    Helper method to check expected fields of a Taxonomy
+    Check taxonomy data
     """
-    assert data["id"] == id
+    assert data["id"] == taxonomy_id
     assert data["name"] == name
     assert data["description"] == description
     assert data["enabled"] == enabled
@@ -53,12 +55,12 @@ def check_taxonomy(
     assert data["visible_to_authors"] == visible_to_authors
 
 
-@ddt.ddt
-class TestTaxonomyViewSet(APITestCase):
+class TestTaxonomyViewMixin(APITestCase):
     """
-    Test of the Taxonomy REST API
+    Mixin for taxonomy views. Adds users.
     """
-    def setUp(self) -> None:
+
+    def setUp(self):
         super().setUp()
 
         self.user = User.objects.create(
@@ -71,6 +73,13 @@ class TestTaxonomyViewSet(APITestCase):
             email="staff@example.com",
             is_staff=True,
         )
+
+
+@ddt.ddt
+class TestTaxonomyViewSet(TestTaxonomyViewMixin):
+    """
+    Test taxonomy view set
+    """
 
     @ddt.data(
         (None, status.HTTP_200_OK, 4),
@@ -238,7 +247,7 @@ class TestTaxonomyViewSet(APITestCase):
         self.client.force_authenticate(user=self.staff)
         response = self.client.post(url, create_data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data["system_defined"] is False
+        assert not response.data["system_defined"]
 
     @ddt.data(
         (None, status.HTTP_403_FORBIDDEN),
@@ -391,7 +400,7 @@ class TestTaxonomyViewSet(APITestCase):
 
         self.client.force_authenticate(user=self.staff)
         response = self.client.delete(url)
-        assert response.status_code, status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @ddt.ddt
@@ -782,3 +791,319 @@ class TestObjectTagViewSet(APITestCase):
 
         response = self.client.put(url, {"tags": ["Tag 1"]}, format="json")
         assert response.status_code == expected_status
+
+
+class TestTaxonomyTagsView(TestTaxonomyViewMixin):
+    """
+    Tests the list tags of taxonomy view
+    """
+
+    fixtures = ["tests/openedx_tagging/core/fixtures/tagging.yaml"]
+
+    def setUp(self):
+        self.small_taxonomy = Taxonomy.objects.get(name="Life on Earth")
+        self.large_taxonomy = Taxonomy(name="Large Taxonomy")
+        self.large_taxonomy.save()
+
+        self.small_taxonomy_url = TAXONOMY_TAGS_URL.format(pk=self.small_taxonomy.pk)
+        self.large_taxonomy_url = TAXONOMY_TAGS_URL.format(pk=self.large_taxonomy.pk)
+
+        self.root_tags_count = 51
+        self.children_tags_count = [12, 12]  # 51 * 12 * 12 = 7344 tags
+
+        self.page_size = TagsPagination().page_size
+
+        return super().setUp()
+
+    def _create_tag(self, depth: int, parent: Tag | None = None):
+        """
+        Creates tags and children in a recursive way.
+        """
+        tag_count = self.large_taxonomy.tag_set.count()
+        tag = Tag(
+            taxonomy=self.large_taxonomy,
+            parent=parent,
+            value=f"Tag {tag_count}",
+        )
+        tag.save()
+        if depth < len(self.children_tags_count):
+            for _ in range(self.children_tags_count[depth]):
+                self._create_tag(depth + 1, parent=tag)
+        return tag
+
+    def _build_large_taxonomy(self):
+        # Pupulates the large taxonomy with tags
+        for _ in range(self.root_tags_count):
+            self._create_tag(0)
+
+    def test_invalid_taxonomy(self):
+        url = TAXONOMY_TAGS_URL.format(pk=212121)
+
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_not_authorized_user(self):
+        # Not authenticated user
+        response = self.client.get(self.small_taxonomy_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        self.small_taxonomy.enabled = False
+        self.small_taxonomy.save()
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.small_taxonomy_url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_small_taxonomy(self):
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(self.small_taxonomy_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+        results = data.get("results", [])
+
+        # Count of root tags
+        root_count = self.small_taxonomy.tag_set.filter(parent=None).count()
+        assert len(results) == root_count
+
+        # Checking tag fields
+        root_tag = self.small_taxonomy.tag_set.get(id=results[0].get("id"))
+        root_children_count = root_tag.children.count()
+        assert results[0].get("value") == root_tag.value
+        assert results[0].get("taxonomy_id") == self.small_taxonomy.id
+        assert results[0].get("children_count") == root_children_count
+        assert len(results[0].get("sub_tags")) == root_children_count
+
+        # Checking pagination values
+        assert data.get("next") is None
+        assert data.get("previous") is None
+        assert data.get("count") == root_count
+        assert data.get("num_pages") == 1
+        assert data.get("current_page") == 1
+
+    def test_small_search(self):
+        search_term = 'eU'
+        url = f"{self.small_taxonomy_url}?search_term={search_term}"
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+        results = data.get("results", [])
+
+        assert len(results) == 3
+
+        # Checking pagination values
+        assert data.get("next") is None
+        assert data.get("previous") is None
+        assert data.get("count") == 3
+        assert data.get("num_pages") == 1
+        assert data.get("current_page") == 1
+
+    def test_large_taxonomy(self):
+        self._build_large_taxonomy()
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(self.large_taxonomy_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+        results = data.get("results", [])
+
+        # Count of paginated root tags
+        assert len(results) == self.page_size
+
+        # Checking tag fields
+        root_tag = self.large_taxonomy.tag_set.get(id=results[0].get("id"))
+        assert results[0].get("value") == root_tag.value
+        assert results[0].get("taxonomy_id") == self.large_taxonomy.id
+        assert results[0].get("parent_id") == root_tag.parent_id
+        assert results[0].get("children_count") == root_tag.children.count()
+        assert results[0].get("sub_tags_link") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}"
+            f"/tags/?parent_tag_id={root_tag.id}"
+        )
+
+        # Checking pagination values
+        assert data.get("next") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}/tags/?page=2"
+        )
+        assert data.get("previous") is None
+        assert data.get("count") == self.root_tags_count
+        assert data.get("num_pages") == 6
+        assert data.get("current_page") == 1
+
+    def test_next_page_large_taxonomy(self):
+        self._build_large_taxonomy()
+        self.client.force_authenticate(user=self.staff)
+
+        # Gets the root tags to obtain the next links
+        response = self.client.get(self.large_taxonomy_url)
+
+        # Gets the next root tags
+        response = self.client.get(response.data.get("next"))
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+
+        # Checking pagination values
+        assert data.get("next") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}/tags/?page=3"
+        )
+        assert data.get("previous") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}/tags/"
+        )
+        assert data.get("count") == self.root_tags_count
+        assert data.get("num_pages") == 6
+        assert data.get("current_page") == 2
+
+    def test_large_search(self):
+        self._build_large_taxonomy()
+        search_term = '1'
+        url = f"{self.large_taxonomy_url}?search_term={search_term}"
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+        results = data.get("results", [])
+
+        # Count of paginated root tags
+        assert len(results) == self.page_size
+
+        # Checking pagination values
+        assert data.get("next") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}"
+            f"/tags/?page=2&search_term={search_term}"
+        )
+        assert data.get("previous") is None
+        assert data.get("count") == 51
+        assert data.get("num_pages") == 6
+        assert data.get("current_page") == 1
+
+    def test_next_large_search(self):
+        self._build_large_taxonomy()
+        search_term = '1'
+        url = f"{self.large_taxonomy_url}?search_term={search_term}"
+
+        # Get first page of the search
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(url)
+
+        # Get next page
+        response = self.client.get(response.data.get("next"))
+
+        data = response.data
+        results = data.get("results", [])
+
+        # Count of paginated root tags
+        assert len(results) == self.page_size
+
+        # Checking pagination values
+        assert data.get("next") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}"
+            f"/tags/?page=3&search_term={search_term}"
+        )
+        assert data.get("previous") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}"
+            f"/tags/?search_term={search_term}"
+        )
+        assert data.get("count") == 51
+        assert data.get("num_pages") == 6
+        assert data.get("current_page") == 2
+
+    def test_get_children(self):
+        self._build_large_taxonomy()
+        self.client.force_authenticate(user=self.staff)
+
+        # Get root tags to obtain the children link of a tag.
+        response = self.client.get(self.large_taxonomy_url)
+        results = response.data.get("results", [])
+
+        # Get children tags
+        response = self.client.get(results[0].get("sub_tags_link"))
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+        results = data.get("results", [])
+
+        # Count of paginated children tags
+        assert len(results) == self.page_size
+
+        # Checking tag fields
+        tag = self.large_taxonomy.tag_set.get(id=results[0].get("id"))
+        assert results[0].get("value") == tag.value
+        assert results[0].get("taxonomy_id") == self.large_taxonomy.id
+        assert results[0].get("parent_id") == tag.parent_id
+        assert results[0].get("children_count") == tag.children.count()
+        assert results[0].get("sub_tags_link") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}"
+            f"/tags/?parent_tag_id={tag.id}"
+        )
+
+        # Checking pagination values
+        assert data.get("next") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}"
+            f"/tags/?page=2&parent_tag_id={tag.parent_id}"
+        )
+        assert data.get("previous") is None
+        assert data.get("count") == self.children_tags_count[0]
+        assert data.get("num_pages") == 2
+        assert data.get("current_page") == 1
+
+    def test_get_leaves(self):
+        # Get tags depth=2
+        self.client.force_authenticate(user=self.staff)
+        parent_tag = Tag.objects.get(value="Animalia")
+
+        # Build url to get tags depth=2
+        url = f"{self.small_taxonomy_url}?parent_tag_id={parent_tag.id}"
+        response = self.client.get(url)
+        results = response.data.get("results", [])
+
+        # Checking tag fields
+        tag = self.small_taxonomy.tag_set.get(id=results[0].get("id"))
+        assert results[0].get("value") == tag.value
+        assert results[0].get("taxonomy_id") == self.small_taxonomy.id
+        assert results[0].get("parent_id") == tag.parent_id
+        assert results[0].get("children_count") == tag.children.count()
+        assert results[0].get("sub_tags_link") is None
+
+    def test_next_children(self):
+        self._build_large_taxonomy()
+        self.client.force_authenticate(user=self.staff)
+
+        # Get roots to obtain children link of a tag
+        response = self.client.get(self.large_taxonomy_url)
+        results = response.data.get("results", [])
+
+        # Get children to obtain next link
+        response = self.client.get(results[0].get("sub_tags_link"))
+
+        # Get next children
+        response = self.client.get(response.data.get("next"))
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.data
+        results = data.get("results", [])
+        tag = self.large_taxonomy.tag_set.get(id=results[0].get("id"))
+
+        # Checking pagination values
+        assert data.get("next") is None
+        assert data.get("previous") == (
+            "http://testserver/tagging/"
+            f"rest_api/v1/taxonomies/{self.large_taxonomy.id}/tags/?parent_tag_id={tag.parent_id}"
+        )
+        assert data.get("count") == self.children_tags_count[0]
+        assert data.get("num_pages") == 2
+        assert data.get("current_page") == 2


### PR DESCRIPTION
## Description

Adds a new view to return tags for a given taxonomy. With this view, you can:

- Return paginated root tags.
- Return paginated children of given tag.
- Search tags in all taxonomy.
- Search tags on a children list.

Also updates the ADR 0014 with some logics on search.

## Supporting Information

- Closes https://github.com/openedx/modular-learning/issues/75

## Testing Instructions

- Ensure that the tests cover the expected behavior of the view as described in the related issue.
- Run this command to create a small taxonomy:

```
python manage.py loaddata tests/openedx_tagging/core/fixtures/tagging.yaml
```

- Run this commands to create a large taxonomy:

```
python manage.py shell
> from tests.openedx_tagging.core.tagging.test_views import TestTaxonomyTagsView
> case = TestTaxonomyTagsView()
> case.setUp()
> case.build_large_taxonomy()
> from openedx_tagging.core.tagging.models import Taxonomy, Tag
> Taxonomy.objects.filter(name="Large Taxonomy")
```

- Run django server: `python manage.py runserver`
- You can comment [this line](https://github.com/openedx/openedx-learning/pull/78/files#diff-215d20c663dcd5727c14740a72d09fe6fd22e3a92fd08db46036e2e799699917R354) to avoid the permissions.
- Make a [Get request](http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/-1/tags/) to get the Languages tags. Verify that all tags are returned. Verify the structure.
- Make a Get request to get the small taxonomy tags: http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/Tax-id/tags/
- Verify that all tags are returned. Verify the tree structure.
- Make a Get request to get the large taxonomy tags.
    - Verify that the root tags are paginated.
    - Verify the structure.
    - Open the next page link.
    - Verify the result.
    - Open a children link.
    - Verify the result.
- Make a Get request to search tags on the small taxonomy:  http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/Tax-id/tags/?search_term=eU
- Verify the results.
- Make a Get request to search tags on the large taxonomy: http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/Tax-id/tags/?search_term=10
- Verify the results.