### PR TITLE
Enforce limit on number of tags per object

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -446,24 +446,25 @@ class Taxonomy(models.Model):
                 -1,
             )
 
-        def _check_current_tag_count() -> None:
+        def _check_new_tag_count(new_tag_count: int) -> None:
             """
-            Checks if the current count of tags for the object is less than 100
+            Checks if the new count of tags for the object is equal or less than 100
             """
             # Exclude self.id to avoid counting the tags that are going to be updated
             current_count = ObjectTag.objects.filter(object_id=object_id).exclude(taxonomy_id=self.id).count()
 
-            if current_count >= 100:
+            if current_count + new_tag_count > 100:
                 raise ValueError(
-                    _(f"Object ({object_id}) already have 100 or more tags.")
+                    _(f"Cannot add more than 100 tags to ({object_id}).")
                 )
 
-        _check_current_tag_count()
 
         if not isinstance(tags, list):
             raise ValueError(_(f"Tags must be a list, not {type(tags).__name__}."))
 
         tags = list(dict.fromkeys(tags))  # Remove duplicates preserving order
+
+        _check_new_tag_count(len(tags))
 
         if not self.allow_multiple and len(tags) > 1:
             raise ValueError(_(f"Taxonomy ({self.id}) only allows one tag per object."))

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -458,7 +458,6 @@ class Taxonomy(models.Model):
                     _(f"Cannot add more than 100 tags to ({object_id}).")
                 )
 
-
         if not isinstance(tags, list):
             raise ValueError(_(f"Tags must be a list, not {type(tags).__name__}."))
 

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -404,6 +404,19 @@ class Taxonomy(models.Model):
                 -1,
             )
 
+        def _check_current_tag_count() -> None:
+            """
+            Checks if the current count of tags for the object is less than 100
+            """
+            current_count = ObjectTag.objects.filter(object_id=object_id).exclude(taxonomy_id=self.id).count()
+
+            if current_count >= 100:
+                raise ValueError(
+                    _(f"Object ({object_id}) already have 100 tags.")
+                )
+
+        _check_current_tag_count()
+
         if not isinstance(tags, list):
             raise ValueError(_(f"Tags must be a list, not {type(tags).__name__}."))
 

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -408,11 +408,12 @@ class Taxonomy(models.Model):
             """
             Checks if the current count of tags for the object is less than 100
             """
+            # Exclude self.id to avoid counting the tags that are going to be updated
             current_count = ObjectTag.objects.filter(object_id=object_id).exclude(taxonomy_id=self.id).count()
 
             if current_count >= 100:
                 raise ValueError(
-                    _(f"Object ({object_id}) already have 100 tags.")
+                    _(f"Object ({object_id}) already have 100 or more tags.")
                 )
 
         _check_current_tag_count()

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.http import Http404
 from rest_framework import mixins
 from rest_framework.exceptions import MethodNotAllowed, PermissionDenied, ValidationError
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from ...api import create_taxonomy, get_object_tags, get_taxonomies, get_taxonomy, tag_object
@@ -171,21 +172,17 @@ class TaxonomyView(ModelViewSet):
 
 class ObjectTagView(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.ListModelMixin, GenericViewSet):
     """
-    View to retrieve paginated ObjectTags for a provided Object ID (object_id).
+    View to retrieve ObjectTags for a provided Object ID (object_id).
 
     **Retrieve Parameters**
         * object_id (required): - The Object ID to retrieve ObjectTags for.
 
     **Retrieve Query Parameters**
         * taxonomy (optional) - PK of taxonomy to filter ObjectTags for.
-        * page (optional) - Page number of paginated results.
-        * page_size (optional) - Number of results included in each page.
 
     **Retrieve Example Requests**
         GET api/tagging/v1/object_tags/:object_id
         GET api/tagging/v1/object_tags/:object_id?taxonomy=1
-        GET api/tagging/v1/object_tags/:object_id?taxonomy=1&page=2
-        GET api/tagging/v1/object_tags/:object_id?taxonomy=1&page=2&page_size=10
 
     **Retrieve Query Returns**
         * 200 - Success
@@ -232,8 +229,7 @@ class ObjectTagView(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.L
 
     def retrieve(self, request, object_id=None):
         """
-        Retrieve ObjectTags that belong to a given object_id and
-        return paginated results.
+        Retrieve ObjectTags that belong to a given object_id
 
         Note: We override `retrieve` here instead of `list` because we are
         passing in the Object ID (object_id) in the path (as opposed to passing
@@ -243,14 +239,12 @@ class ObjectTagView(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.L
         behavior we want.
         """
         object_tags = self.get_queryset()
-        paginated_object_tags = self.paginate_queryset(object_tags)
-        serializer = ObjectTagSerializer(paginated_object_tags, many=True)
-        return self.get_paginated_response(serializer.data)
+        serializer = ObjectTagSerializer(object_tags, many=True)
+        return Response(serializer.data)
 
     def update(self, request, object_id, partial=False):
         """
-        Update ObjectTags that belong to a given object_id and
-        return the list of these ObjecTags paginated.
+        Update ObjectTags that belong to a given object_id
 
         Pass a list of Tag ids or Tag values to be applied to an object id in the
         body `tag` parameter. Passing an empty list will remove all tags from

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -500,3 +500,4 @@ class TaxonomyTagsView(ListAPIView):
         self.pagination_class = self.get_pagination_class()
 
         return result
+

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -7,8 +7,8 @@ from django.db import models
 from django.http import Http404
 from rest_framework import mixins
 from rest_framework.exceptions import MethodNotAllowed, PermissionDenied, ValidationError
-from rest_framework.response import Response
 from rest_framework.generics import ListAPIView
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from openedx_tagging.core.tagging.models.base import Tag

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -500,4 +500,3 @@ class TaxonomyTagsView(ListAPIView):
         self.pagination_class = self.get_pagination_class()
 
         return result
-

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -568,7 +568,6 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
                 "object_1",
             )
 
-
     def test_get_object_tags(self) -> None:
         # Alpha tag has no taxonomy
         alpha = ObjectTag(object_id="abc")

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -558,6 +558,7 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
                 ["Eubacteria"],
                 "object_1",
             )
+            assert "already have 100 or more tags" in str(exc.exception)
 
         # Updating existing tags should work
         for taxonomy in self.dummy_taxonomies:

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -606,7 +606,8 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
                 ["Eubacteria"],
                 "object_1",
             )
-            assert "already have 100 or more tags" in str(exc.exception)
+            assert exc.exception
+            assert "Cannot add more than 100 tags to" in str(exc.exception)
 
         # Updating existing tags should work
         for taxonomy in self.dummy_taxonomies:
@@ -615,6 +616,17 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
                 ["New Dummy Tag"],
                 "object_1",
             )
+
+        # Updating existing tags adding a new one should fail
+        for taxonomy in self.dummy_taxonomies:
+            with self.assertRaises(ValueError) as exc:
+                tagging_api.tag_object(
+                    taxonomy,
+                    ["New Dummy Tag 1", "New Dummy Tag 2"],
+                    "object_1",
+                )
+                assert exc.exception
+                assert "Cannot add more than 100 tags to" in str(exc.exception)
 
     def test_get_object_tags(self) -> None:
         # Alpha tag has no taxonomy

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -93,6 +93,17 @@ class TestTagTaxonomyMixin:
             get_tag("System Tag 4"),
         ]
 
+        self.dummy_taxonomies = []
+        for i in range(100):
+            taxonomy = Taxonomy.objects.create(name=f"ZZ Dummy Taxonomy {i:03}", allow_free_text=True)
+            ObjectTag.objects.create(
+                object_id="limit_tag_count",
+                taxonomy=taxonomy,
+                _name=taxonomy.name,
+                _value="Dummy Tag",
+            )
+            self.dummy_taxonomies.append(taxonomy)
+
     def setup_tag_depths(self):
         """
         Annotate our tags with depth so we can compare them.

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -117,7 +117,11 @@ class TestTagTaxonomyMixin:
 
         self.dummy_taxonomies = []
         for i in range(100):
-            taxonomy = Taxonomy.objects.create(name=f"ZZ Dummy Taxonomy {i:03}", allow_free_text=True)
+            taxonomy = Taxonomy.objects.create(
+                name=f"ZZ Dummy Taxonomy {i:03}",
+                allow_free_text=True,
+                allow_multiple=True
+            )
             ObjectTag.objects.create(
                 object_id="limit_tag_count",
                 taxonomy=taxonomy,

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -732,7 +732,4 @@ class TestObjectTagViewSet(APITestCase):
 
         response = self.client.put(url, {"tags": ["Tag 1"]}, format="json")
         assert response.status_code == expected_status
-        if status.is_success(expected_status):
-            assert len(response.data) == 1
-            assert set(t["value"] for t in response.data) == set(["Tag 1"])
-
+        assert not status.is_success(expected_status)  # No success cases here

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -406,7 +406,7 @@ class TestObjectTagViewSet(APITestCase):
             """
             Everyone have object permission on object_id "abc"
             """
-            return object_id == "abc" or object_id == "limit_tag_count"
+            return object_id in ("abc", "limit_tag_count")
 
         super().setUp()
 
@@ -461,7 +461,12 @@ class TestObjectTagViewSet(APITestCase):
         self.dummy_taxonomies = []
         for i in range(100):
             taxonomy = Taxonomy.objects.create(name=f"Dummy Taxonomy {i}", allow_free_text=True)
-            ObjectTag.objects.create(object_id="limit_tag_count", taxonomy=taxonomy, _name=taxonomy.name, _value="Dummy Tag")
+            ObjectTag.objects.create(
+                object_id="limit_tag_count",
+                taxonomy=taxonomy,
+                _name=taxonomy.name,
+                _value="Dummy Tag"
+            )
             self.dummy_taxonomies.append(taxonomy)
 
         # Override the object permission for the test

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -469,7 +469,11 @@ class TestObjectTagViewSet(APITestCase):
 
         self.dummy_taxonomies = []
         for i in range(100):
-            taxonomy = Taxonomy.objects.create(name=f"Dummy Taxonomy {i}", allow_free_text=True)
+            taxonomy = Taxonomy.objects.create(
+                name=f"Dummy Taxonomy {i}",
+                allow_free_text=True,
+                allow_multiple=True
+            )
             ObjectTag.objects.create(
                 object_id="limit_tag_count",
                 taxonomy=taxonomy,
@@ -770,6 +774,12 @@ class TestObjectTagViewSet(APITestCase):
             url = OBJECT_TAGS_UPDATE_URL.format(object_id=object_id, taxonomy_id=taxonomy.pk)
             response = self.client.put(url, {"tags": ["New Tag"]}, format="json")
             assert response.status_code == status.HTTP_200_OK
+
+        # Editing tags adding another one will fail
+        for taxonomy in self.dummy_taxonomies:
+            url = OBJECT_TAGS_UPDATE_URL.format(object_id=object_id, taxonomy_id=taxonomy.pk)
+            response = self.client.put(url, {"tags": ["New Tag 1", "New Tag 2"]}, format="json")
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 class TestTaxonomyTagsView(TestTaxonomyViewMixin):

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -756,7 +756,6 @@ class TestObjectTagViewSet(APITestCase):
         # Can't add another tag because the object already has 100 tags
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-
         # The user can edit the tags that are already on the object
         for taxonomy in self.dummy_taxonomies:
             url = OBJECT_TAGS_UPDATE_URL.format(object_id=object_id, taxonomy_id=taxonomy.pk)


### PR DESCRIPTION
## Description

This PR enforces a 100 hardcoded limit on the number of ObjectTags applied on any object. It also removes the pagination of the tagging REST API for listing and updating object tags.

## Supporting Information

* Closes https://github.com/openedx/modular-learning/issues/99

## Testing instructions
* Please ensure that the tests cover the expected behavior of the view as described in the related issue.

## After merge
- [ ] Create a Tag with the version `v0.1.7`
____
Private-ref: [FAL-3501](https://tasks.opencraft.com/browse/FAL-3501)