### PR TITLE
Simplify Tag Models [WIP] [FC-0030]

### DIFF
--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 from typing import Iterator
 
-from django.db.models import QuerySet
+from django.db import transaction
+from django.db.models import QuerySet, F
 from django.utils.translation import gettext_lazy as _
 
 from .models import ObjectTag, Tag, Taxonomy
@@ -139,21 +140,16 @@ def resync_object_tags(object_tags: QuerySet | None = None) -> int:
 
 
 def get_object_tags(
-    object_id: str, taxonomy_id: str | None = None
+    object_id: str,
+    ObjectTagClass: type[ObjectTag] = ObjectTag
 ) -> QuerySet[ObjectTag]:
     """
     Returns a Queryset of object tags for a given object.
 
     Pass taxonomy to limit the returned object_tags to a specific taxonomy.
     """
-    ObjectTagClass = ObjectTag
-    extra_filters = {}
-    if taxonomy_id is not None:
-        taxonomy = Taxonomy.objects.get(pk=taxonomy_id)
-        ObjectTagClass = taxonomy.object_tag_class
-        extra_filters["taxonomy_id"] = taxonomy_id
     tags = (
-        ObjectTagClass.objects.filter(object_id=object_id, **extra_filters)
+        ObjectTagClass.objects.filter(object_id=object_id)
         .select_related("tag", "taxonomy")
         .order_by("id")
     )
@@ -164,9 +160,7 @@ def delete_object_tags(object_id: str):
     """
     Delete all ObjectTag entries for a given object.
     """
-    tags = ObjectTag.objects.filter(
-        object_id=object_id,
-    )
+    tags = ObjectTag.objects.filter(object_id=object_id)
 
     tags.delete()
 
@@ -175,6 +169,7 @@ def tag_object(
     taxonomy: Taxonomy,
     tags: list[str],
     object_id: str,
+    ObjectTagClass: type[ObjectTag] = ObjectTag,
 ) -> list[ObjectTag]:
     """
     Replaces the existing ObjectTag entries for the given taxonomy + object_id with the given list of tags.
@@ -185,9 +180,77 @@ def tag_object(
     Raised ValueError if the proposed tags are invalid for this taxonomy.
     Preserves existing (valid) tags, adds new (valid) tags, and removes omitted (or invalid) tags.
     """
-    return taxonomy.cast().tag_object(tags, object_id)
+
+    def _check_new_tag_count(new_tag_count: int) -> None:
+        """
+        Checks if the new count of tags for the object is equal or less than 100
+        """
+        # Exclude self.id to avoid counting the tags that are going to be updated
+        current_count = ObjectTag.objects.filter(object_id=object_id).exclude(taxonomy_id=taxonomy.id).count()
+
+        if current_count + new_tag_count > 100:
+            raise ValueError(
+                _(f"Cannot add more than 100 tags to ({object_id}).")
+            )
+
+    if not isinstance(tags, list):
+        raise ValueError(_(f"Tags must be a list, not {type(tags).__name__}."))
+
+    taxonomy = taxonomy.cast()  # Make sure we're using the right subclass. This is a no-op if we are already.
+    tags = list(dict.fromkeys(tags))  # Remove duplicates preserving order
+
+    _check_new_tag_count(len(tags))
+
+    if not taxonomy.allow_multiple and len(tags) > 1:
+        raise ValueError(_(f"Taxonomy ({taxonomy.name}) only allows one tag per object."))
+
+    if taxonomy.required and len(tags) == 0:
+        raise ValueError(
+            _(f"Taxonomy ({taxonomy.id}) requires at least one tag per object.")
+        )
+
+    current_tags = list(
+        ObjectTagClass.objects.filter(taxonomy=taxonomy, object_id=object_id)
+    )
+    updated_tags = []
+    if taxonomy.allow_free_text:
+        for tag_value in tags:
+            object_tag_index = next((i for (i, t) in enumerate(current_tags) if t._value == tag_value), -1)
+            if object_tag_index >= 0:
+                # This tag is already applied.
+                object_tag = current_tags.pop(object_tag_index)
+            else:
+                object_tag = ObjectTagClass(taxonomy=taxonomy, object_id=object_id, _value=tag_value)
+                updated_tags.append(object_tag)
+    else:
+        # Handle closed taxonomies:
+        for tag_ref in tags:
+            tag = taxonomy.tag_set.get(pk=tag_ref)  # TODO: this should be taxonomy.tag_for_value(tag_value)
+            object_tag_index = next((i for (i, t) in enumerate(current_tags) if t.tag_id == tag.id), -1)
+            if object_tag_index >= 0:
+                # This tag is already applied.
+                object_tag = current_tags.pop(object_tag_index)
+                if object_tag._value != tag.value:
+                    # The ObjectTag's cached '_value' is out of sync with the Tag, so update it:
+                    object_tag._value = tag.value
+                    updated_tags.append(object_tag)
+            else:
+                # We are newly applying this tag:
+                object_tag = ObjectTagClass(taxonomy=taxonomy, object_id=object_id, tag=tag, _value=tag.value)
+                updated_tags.append(object_tag)
+
+    # Save all updated tags at once to avoid partial updates
+    with transaction.atomic():
+        for object_tag in updated_tags:
+            object_tag.save()
+        # ...and delete any omitted existing tags
+        for old_tag in current_tags:
+            old_tag.delete()
+
+    return updated_tags
 
 
+# TODO: return tags from closed taxonomies as well as the count of how many times each is used.
 def autocomplete_tags(
     taxonomy: Taxonomy,
     search: str,
@@ -228,4 +291,25 @@ def autocomplete_tags(
                 "using get_tags() and filtering them on the frontend."
             )
         )
-    return taxonomy.cast().autocomplete_tags(search, object_id)
+    # Fetch tags that the object already has to exclude them from the result
+    excluded_tags: list[str] = []
+    if object_id:
+        excluded_tags = list(
+            taxonomy.objecttag_set.filter(object_id=object_id).values_list(
+                "_value", flat=True
+            )
+        )
+    return (
+        # Fetch object tags from this taxonomy whose value contains the search
+        taxonomy.objecttag_set.filter(_value__icontains=search)
+        # omit any tags whose values match the tags on the given object
+        .exclude(_value__in=excluded_tags)
+        # alphabetical ordering
+        .order_by("_value")
+        # Alias the `_value` field to `value` to make it nicer for users
+        .annotate(value=F("_value"))
+        # obtain tag values
+        .values("value", "tag_id")
+        # remove repeats
+        .distinct()
+    )

--- a/openedx_tagging/core/tagging/models/__init__.py
+++ b/openedx_tagging/core/tagging/models/__init__.py
@@ -1,3 +1,3 @@
 from .base import ObjectTag, Tag, Taxonomy
 from .import_export import TagImportTask, TagImportTaskState
-from .system_defined import LanguageTaxonomy, ModelObjectTag, ModelSystemDefinedTaxonomy, UserSystemDefinedTaxonomy
+from .system_defined import LanguageTaxonomy, ModelSystemDefinedTaxonomy, UserSystemDefinedTaxonomy

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -53,7 +53,6 @@ class ObjectTagSerializer(serializers.ModelSerializer):
             "name",
             "value",
             "taxonomy_id",
-            "tag_ref",
             "is_valid",
         ]
 

--- a/tests/openedx_tagging/core/tagging/test_system_defined_models.py
+++ b/tests/openedx_tagging/core/tagging/test_system_defined_models.py
@@ -2,14 +2,16 @@
 Test the tagging system-defined taxonomy models
 """
 from __future__ import annotations
+from datetime import datetime
 
 import ddt  # type: ignore[import]
-from django.contrib.auth import get_user_model
-from django.db.utils import IntegrityError
 from django.test import TestCase, override_settings
+import pytest
 
+from openedx_learning.core.publishing.models import LearningPackage
+from openedx_tagging.core.tagging import api
+from openedx_tagging.core.tagging.models import Taxonomy
 from openedx_tagging.core.tagging.models.system_defined import (
-    ModelObjectTag,
     ModelSystemDefinedTaxonomy,
     UserSystemDefinedTaxonomy,
 )
@@ -18,6 +20,7 @@ from .test_models import TestTagTaxonomyMixin
 
 test_languages = [
     ("en", "English"),
+    ("en-uk", "English (United Kingdom)"),
     ("az", "Azerbaijani"),
     ("id", "Indonesian"),
     ("qu", "Quechua"),
@@ -46,29 +49,21 @@ class InvalidModelTaxonomy(ModelSystemDefinedTaxonomy):
         app_label = "oel_tagging"
 
 
-class TestModelTag(ModelObjectTag):
+class TestLPTaxonomy(ModelSystemDefinedTaxonomy):
     """
-    Model used for testing
+    Model used for testing - points to LearningPackage instances
     """
-
     @property
     def tag_class_model(self):
-        return get_user_model()
-
-    class Meta:
-        proxy = True
-        managed = False
-        app_label = "oel_tagging"
-
-
-class TestModelTaxonomy(ModelSystemDefinedTaxonomy):
-    """
-    Model used for testing
-    """
+        return LearningPackage
 
     @property
-    def object_tag_class(self):
-        return TestModelTag
+    def tag_class_value_field(self) -> str:
+        return "key"
+
+    @property
+    def tag_class_key_field(self) -> str:
+        return "uuid"
 
     class Meta:
         proxy = True
@@ -82,122 +77,165 @@ class TestModelSystemDefinedTaxonomy(TestTagTaxonomyMixin, TestCase):
     Test for Model Model System defined taxonomy
     """
 
+    @staticmethod
+    def _create_learning_pkg(**kwargs) -> LearningPackage:
+        timestamp = datetime.now()
+        return LearningPackage.objects.create(**kwargs, created=timestamp, updated=timestamp)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create two learning packages and a taxonomy that can tag any object using learning packages as tags:
+        cls.learning_pkg_1 = cls._create_learning_pkg(key="p1", title="Learning Package 1")
+        cls.learning_pkg_2 = cls._create_learning_pkg(key="p2", title="Learning Package 2")
+        cls.lp_taxonomy = TestLPTaxonomy.objects.create(
+            taxonomy_class=TestLPTaxonomy,
+            name="LearningPackage Taxonomy",
+            allow_multiple=True,
+        )
+        # Also create an "Author" taxonomy that can tag any object using user IDs/usernames:
+        cls.author_taxonomy = UserSystemDefinedTaxonomy.objects.create(
+            taxonomy_class=UserSystemDefinedTaxonomy,
+            name="Authors",
+            allow_multiple=True,
+        )
+
+    def test_lp_taxonomy_validation(self):
+        """
+        Test that the validation methods of the Learning Package Taxonomy are working
+        """
+        # Create a new LearningPackage - we know no Tag instances will exist for it yet.
+        valid_lp = self._create_learning_pkg(key="valid-lp", title="New Learning Packacge")
+        # The taxonomy can validate tags by value which we've defined as they 'key' of the LearningPackage:
+        assert self.lp_taxonomy.validate_value(self.learning_pkg_2.key) is True
+        assert self.lp_taxonomy.validate_value(self.learning_pkg_2.key) is True
+        assert self.lp_taxonomy.validate_value(valid_lp.key) is True
+        assert self.lp_taxonomy.validate_value("foo") is False
+        # The taxonomy can also validate tags by external_id, which we've defined as the UUID of the LearningPackage:
+        assert self.lp_taxonomy.validate_external_id(self.learning_pkg_2.uuid) is True
+        assert self.lp_taxonomy.validate_external_id(self.learning_pkg_2.uuid) is True
+        assert self.lp_taxonomy.validate_external_id(valid_lp.uuid) is True
+        assert self.lp_taxonomy.validate_external_id("ba11225e-9ec9-4a50-87ea-3155c7c20466") is False
+
+    def test_author_taxonomy_validation(self):
+        """
+        Test the validation methods of the Author Taxonomy (Author = User)
+        """
+        assert self.author_taxonomy.validate_value(self.user_1.username) is True
+        assert self.author_taxonomy.validate_value(self.user_2.username) is True
+        assert self.author_taxonomy.validate_value("not a user") is False
+        # And we can validate by ID if we want:
+        assert self.author_taxonomy.validate_external_id(str(self.user_1.id)) is True
+        assert self.author_taxonomy.validate_external_id(str(self.user_2.id)) is True
+        assert self.author_taxonomy.validate_external_id("8742590") is False
+
     @ddt.data(
-        (ModelSystemDefinedTaxonomy, NotImplementedError),
-        (ModelObjectTag, NotImplementedError),
-        (InvalidModelTaxonomy, AssertionError),
-        (UserSystemDefinedTaxonomy, None),
+        "validate_value", "tag_for_value", "validate_external_id", "tag_for_external_id",
     )
-    @ddt.unpack
-    def test_implementation_error(self, taxonomy_cls, expected_exception):
-        if not expected_exception:
-            assert taxonomy_cls()
-        else:
-            with self.assertRaises(expected_exception):
-                taxonomy_cls()
+    def test_warns_uncasted(self, method):
+        """
+        Test that if we use a taxonomy directly without cast(), we get warned.
+        """
+        base_taxonomy = Taxonomy.objects.get(pk=self.lp_taxonomy.pk)
+        with pytest.raises(TypeError) as excinfo:
+            # e.g. base_taxonomy.validate_value("foo")
+            getattr(base_taxonomy, method)("foo")
+        assert "Taxonomy was used incorrectly - without .cast()" in str(excinfo.value)
 
-    # FIXME: something is wrong with this test case. It's setting the string
-    # "tag_id" as the primary key (integer) of the Tag instance, and it mentions
-    # "parent validation" but there is nothing to do with parents here.
-    #
-    # @ddt.data(
-    #     ("1", "tag_id", True),  # Valid
-    #     ("0", "tag_id", False),  # Invalid user
-    #     ("test_id", "tag_id", False),  # Invalid user id
-    #     ("1", None, False),  # Testing parent validations
-    # )
-    # @ddt.unpack
-    # def test_validations(self, tag_external_id: str, tag_id: str | None, expected: bool) -> None:
-    #     tag = Tag(
-    #         id=tag_id,
-    #         taxonomy=self.user_taxonomy,
-    #         value="_val",
-    #         external_id=tag_external_id,
-    #     )
-    #     object_tag = ObjectTag(
-    #         object_id="id",
-    #         tag=tag,
-    #     )
-    #
-    #     assert self.user_taxonomy.validate_object_tag(
-    #         object_tag=object_tag,
-    #         check_object=False,
-    #         check_taxonomy=False,
-    #         check_tag=True,
-    #     ) == expected
+    def test_simple_tag_object(self):
+        """
+        Test applying tags to an object.
+        """
+        object1_id, object2_id = "obj1", "obj2"
+        api.tag_object(self.lp_taxonomy, ["p1"], object1_id)
+        api.tag_object(self.lp_taxonomy, ["p1", "p2"], object2_id)
+        assert [t.value for t in api.get_object_tags(object1_id)] == ["p1"]
+        assert [t.value for t in api.get_object_tags(object2_id)] == ["p1", "p2"]
 
-    def test_tag_object_invalid_user(self):
-        # Test user that doesn't exist
-        with self.assertRaises(ValueError):
-            self.user_taxonomy.tag_object(tags=[4], object_id="object_id")
+    def test_invalid_tag(self):
+        """
+        Trying to apply an invalid tag raises TagDoesNotExist
+        """
+        with pytest.raises(api.TagDoesNotExist):
+            api.tag_object(self.lp_taxonomy, ["nonexistent"], "obj1")
 
-    def _tag_object(self):
-        return self.user_taxonomy.tag_object(
-            tags=[self.user_1.id], object_id="object_id"
+    def test_case_insensitive_values(self):
+        """
+        For now, values are case insensitive. We may change that in the future.
+        """
+        object1_id, object2_id = "obj1", "obj2"
+        api.tag_object(self.lp_taxonomy, ["P1"], object1_id)
+        api.tag_object(self.lp_taxonomy, ["p1", "P2"], object2_id)
+        assert [t.value for t in api.get_object_tags(object1_id)] == ["p1"]
+        assert [t.value for t in api.get_object_tags(object2_id)] == ["p1", "p2"]
+
+    def test_multiple_taxonomies(self):
+        """
+        Test using several different instances of a taxonomy to tag the same object
+        """
+        reviewer_taxonomy = UserSystemDefinedTaxonomy.objects.create(
+            taxonomy_class=UserSystemDefinedTaxonomy,
+            name="Reviewer",
+            allow_multiple=True,
         )
+        pr_1_id, pr_2_id = "pull_request_1", "pull_request_2"
 
-    def test_tag_object_tag_creation(self):
-        # Test creation of a new Tag with user taxonomy
-        assert self.user_taxonomy.tag_set.count() == 0
-        updated_tags = self._tag_object()
-        assert self.user_taxonomy.tag_set.count() == 1
-        assert len(updated_tags) == 1
-        assert updated_tags[0].tag.external_id == str(self.user_1.id)
-        assert updated_tags[0].tag.value == self.user_1.get_username()
+        # Tag PR 1 as having "Author: user1, user2; Reviewer: user2"
+        api.tag_object(self.author_taxonomy, [self.user_1.username, self.user_2.username], pr_1_id)
+        api.tag_object(reviewer_taxonomy, [self.user_2.username], pr_1_id)
 
-        # Test parent functions
-        taxonomy = TestModelTaxonomy(
-            name="Test",
-            description="Test",
-        )
-        taxonomy.save()
-        assert taxonomy.tag_set.count() == 0
-        updated_tags = taxonomy.tag_object(tags=[self.user_1.id], object_id="object_id")
-        assert taxonomy.tag_set.count() == 1
-        assert taxonomy.tag_set.count() == 1
-        assert len(updated_tags) == 1
-        assert updated_tags[0].tag.external_id == str(self.user_1.id)
-        assert updated_tags[0].tag.value == str(self.user_1.id)
+        # Tag PR 2 as having "Author: user2, reviewer: user1"
+        api.tag_object(self.author_taxonomy, [self.user_2.username], pr_2_id)
+        api.tag_object(reviewer_taxonomy, [self.user_1.username], pr_2_id)
 
-    def test_tag_object_existing_tag(self):
-        # Test add an existing Tag
-        self._tag_object()
-        assert self.user_taxonomy.tag_set.count() == 1
-        with self.assertRaises(IntegrityError):
-            self._tag_object()
+        # Check the results:
+        assert [f"{t.taxonomy.name}:{t.value}" for t in api.get_object_tags(pr_1_id)] == [
+            f"Authors:{self.user_1.username}",
+            f"Authors:{self.user_2.username}",
+            f"Reviewer:{self.user_2.username}",
+        ]
+        assert [f"{t.taxonomy.name}:{t.value}" for t in api.get_object_tags(pr_2_id)] == [
+            f"Authors:{self.user_2.username}",
+            f"Reviewer:{self.user_1.username}",
+        ]
 
     def test_tag_object_resync(self):
-        self._tag_object()
-
-        self.user_1.username = "new_username"
+        """
+        If the value changes, we can use the new value to tag objects, and the
+        Tag will be updated automatically.
+        """
+        # Tag two objects with "Author: user_1"
+        object1_id, object2_id, other_obj_id = "obj1", "obj2", "other"
+        api.tag_object(self.author_taxonomy, [self.user_1.username], object1_id)
+        api.tag_object(self.author_taxonomy, [self.user_1.username], object2_id)
+        initial_object_tags = api.get_object_tags(object1_id)
+        assert [t.value for t in initial_object_tags] == [self.user_1.username]
+        assert list(api.get_object_tags(other_obj_id)) == []
+        # Change user_1's username:
+        new_username = "new_username"
+        self.user_1.username = new_username
         self.user_1.save()
-        updated_tags = self._tag_object()
-        assert self.user_taxonomy.tag_set.count() == 1
-        assert len(updated_tags) == 1
-        assert updated_tags[0].tag.external_id == str(self.user_1.id)
-        assert updated_tags[0].tag.value == self.user_1.get_username()
+        # Now we update the tags on just one of the objects:
+        api.tag_object(self.author_taxonomy, [new_username], object1_id)
+        assert [t.value for t in api.get_object_tags(object1_id)] == [new_username]
+        # But because this will have updated the shared Tag instance, object2 will also be updated as a side effect.
+        # This is good - all the objects throughout the system with this tag now show the new value.
+        assert [t.value for t in api.get_object_tags(object2_id)] == [new_username]
+        # And just to make sure there are no other random changes to other objects:
+        assert list(api.get_object_tags(other_obj_id)) == []
 
     def test_tag_object_delete_user(self):
+        """
+        Using a deleted model instance as a tag will raise TagDoesNotExist
+        """
+        # Tag an object with "Author: user_1"
+        object_id = "obj123"
+        api.tag_object(self.author_taxonomy, [self.user_1.username], object_id)
+        assert [t.value for t in api.get_object_tags(object_id)] == [self.user_1.username]
         # Test after delete user
-        self._tag_object()
-        user_1_id = self.user_1.id
         self.user_1.delete()
-        with self.assertRaises(ValueError):
-            self.user_taxonomy.tag_object(
-                tags=[user_1_id],
-                object_id="object_id",
-            )
-
-    def test_tag_ref(self):
-        object_tag = TestModelTag()
-        object_tag.tag_ref = 1
-        object_tag.save()
-        assert object_tag.tag is None
-        assert object_tag.value == 1
-
-    def test_get_instance(self):
-        object_tag = TestModelTag()
-        assert object_tag.get_instance() is None
+        with self.assertRaises(api.TagDoesNotExist):
+            api.tag_object(self.author_taxonomy, [self.user_1.username], object_id)
 
 
 @ddt.ddt
@@ -207,37 +245,25 @@ class TestLanguageTaxonomy(TestTagTaxonomyMixin, TestCase):
     Test for Language taxonomy
     """
 
-    # FIXME: something is wrong with this test case. It's setting the string
-    # "tag_id" as the primary key (integer) of the Tag instance, and it mentions
-    # "parent validation" but there is nothing to do with parents here.
-    #
-    # @ddt.data(
-    #     ("en", "tag_id", True),  # Valid
-    #     ("es", "tag_id", False),  # Not available lang
-    #     ("en", None, False),  # Test parent validations
-    # )
-    # @ddt.unpack
-    # def test_validations(self, lang: str, tag_id: str | None, expected: bool):
-    #     tag = Tag(
-    #         id=tag_id,
-    #         taxonomy=self.language_taxonomy,
-    #         value="_val",
-    #         external_id=lang,
-    #     )
-    #     object_tag = ObjectTag(
-    #         object_id="id",
-    #         tag=tag,
-    #     )
-    #     assert self.language_taxonomy.validate_object_tag(
-    #         object_tag=object_tag,
-    #         check_object=False,
-    #         check_taxonomy=False,
-    #         check_tag=True,
-    #     ) == expected
+    def test_validate_lang_ids(self):
+        """
+        Whether or not languages are available as tags depends on the django settings
+        """
+        assert self.language_taxonomy.validate_external_id("en") is True
+        assert self.language_taxonomy.tag_for_external_id("en").value == "English"
+        assert self.language_taxonomy.tag_for_external_id("en-uk").value == "English (United Kingdom)"
+        assert self.language_taxonomy.tag_for_external_id("id").value == "Indonesian"
 
-    def test_get_tags(self):
-        tags = self.language_taxonomy.get_tags()
-        expected_langs = [lang[0] for lang in test_languages]
-        for tag in tags:
-            assert tag.external_id in expected_langs
-            assert tag.annotated_field == 0
+        assert self.language_taxonomy.validate_external_id("xx") is False
+        with pytest.raises(api.TagDoesNotExist):
+            self.language_taxonomy.tag_for_external_id("xx")
+
+    @override_settings(LANGUAGES=[("fr", "Français")])
+    def test_minimal_languages(self):
+        """
+        Whether or not languages are available as tags depends on the django settings
+        """
+        assert self.language_taxonomy.validate_external_id("en") is False
+        with pytest.raises(api.TagDoesNotExist):
+            self.language_taxonomy.tag_for_external_id("en")
+        assert self.language_taxonomy.tag_for_external_id("fr").value == "Français"


### PR DESCRIPTION
This is my work on https://github.com/openedx/modular-learning/issues/85 , "clean up tagging models".

I have a few other cleanups in mind but I'm trying to keep this PR focused on one idea: Taxonomies are not aware of Objects. The Taxonomy cannot specify what types of objects it applies to, nor which ObjectTag subclass it works with. Instead that can be specified at a higher level in the API.

So the changes include:
* Removed `Taxonomy.object_tag_class` - taxonomies no longer specify what type of objects they can tag
* Removed `ModelObjectTag` - ObjectTag should only be subclassed to tag different types of objects, not to use different types of tags. It was confusing that we used `ContentObjectTag` when we want to tag content objects, but `ModelObjectTag` when we want to use Tags that are defined from another model.
* Moved `tag_object` and `autocomplete_tags` from `Taxonomy` to be python functions in the API. These were not actually being subclasses anyways so don't need to be instance methods.
* Removed `tag_ref` - **all tags are now set by value**. This makes things simpler and more consistent. (Values may change, it's true, but at any given point in time a value is a unique ID within a given taxonomy, and values are what users see. Tag IDs are still used internally and exposed via the API, but not used when setting tags. This lets us remove `tag_ref` and logic that was in `ObjectTag` is moved to more appropriate places.)

## TODO

This is still a work in progress. I have all the tests in `test_system_defined_models` working, but I have to update the other test cases and the corresponding edx-platform code. You can let me know your thoughts on this refactor now though!


Private-ref: [FAL-3477](https://tasks.opencraft.com/browse/FAL-3477)