### PR TITLE
feat: CRUD API for Taxonomy Tags [FC-0036]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -329,7 +329,16 @@ def add_tag_to_taxonomy(
     Taxonomy, an exception is raised, otherwise the newly created
     Tag is returned
     """
-    return taxonomy.cast().add_tag(tag, parent_tag_value, external_id)
+    taxonomy = taxonomy.cast()
+    new_tag = taxonomy.add_tag(tag, parent_tag_value, external_id)
+
+    # Resync all related ObjectTags after creating new Tag to
+    # to ensure any existing ObjectTags with the same value will
+    # be linked to the new Tag
+    object_tags = taxonomy.objecttag_set.all()
+    resync_object_tags(object_tags)
+
+    return new_tag
 
 
 def update_tag_in_taxonomy(taxonomy: Taxonomy, tag: str, new_value: str):
@@ -361,7 +370,3 @@ def delete_tags_from_taxonomy(
     """
     taxonomy = taxonomy.cast()
     taxonomy.delete_tags(tags, with_subtags)
-
-    # Resync all related ObjectTags after deleting the Tag(s)
-    object_tags = taxonomy.objecttag_set.all()
-    resync_object_tags(object_tags)

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -321,7 +321,7 @@ def autocomplete_tags(
 def add_tag_to_taxonomy(
     taxonomy: Taxonomy,
     tag: str,
-    parent_tag_id: int | None = None,
+    parent_tag_value: str | None = None,
     external_id: str | None = None
 ) -> Tag:
     """
@@ -329,18 +329,18 @@ def add_tag_to_taxonomy(
     Taxonomy, an exception is raised, otherwise the newly created
     Tag is returned
     """
-    return taxonomy.cast().add_tag(tag, parent_tag_id, external_id)
+    return taxonomy.cast().add_tag(tag, parent_tag_value, external_id)
 
 
-def update_tag_in_taxonomy(taxonomy: Taxonomy, tag: int, tag_value: str):
+def update_tag_in_taxonomy(taxonomy: Taxonomy, tag: str, new_value: str):
     """
     Update a Tag that belongs to a Taxonomy. The related ObjectTags are
     updated accordingly.
 
-    Currently only support updates the Tag value.
+    Currently only supports updating the Tag value.
     """
     taxonomy = taxonomy.cast()
-    updated_tag = taxonomy.update_tag(tag, tag_value)
+    updated_tag = taxonomy.update_tag(tag, new_value)
 
     # Resync all related ObjectTags to update to the new Tag value
     object_tags = taxonomy.objecttag_set.all()
@@ -351,7 +351,7 @@ def update_tag_in_taxonomy(taxonomy: Taxonomy, tag: int, tag_value: str):
 
 def delete_tags_from_taxonomy(
     taxonomy: Taxonomy,
-    tag_ids: list[int],
+    tags: list[str],
     with_subtags: bool
 ):
     """
@@ -360,7 +360,7 @@ def delete_tags_from_taxonomy(
     the sub-tags will be deleted as well.
     """
     taxonomy = taxonomy.cast()
-    taxonomy.delete_tags(tag_ids, with_subtags)
+    taxonomy.delete_tags(tags, with_subtags)
 
     # Resync all related ObjectTags after deleting the Tag(s)
     object_tags = taxonomy.objecttag_set.all()

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -129,13 +129,7 @@ def resync_object_tags(object_tags: QuerySet | None = None) -> int:
     if not object_tags:
         object_tags = ObjectTag.objects.select_related("tag", "taxonomy")
 
-    num_changed = 0
-    for object_tag in object_tags:
-        changed = object_tag.resync()
-        if changed:
-            object_tag.save()
-            num_changed += 1
-    return num_changed
+    return ObjectTag.resync_object_tags(object_tags)
 
 
 def get_object_tags(
@@ -329,3 +323,13 @@ def add_tag_to_taxonomy(
     Tag is returned
     """
     return taxonomy.cast().add_tag(tag, parent_tag_id, external_id)
+
+
+def update_tag_in_taxonomy(taxonomy: Taxonomy, tag: int, tag_value: str):
+    """
+    Update a Tag that belongs to a Taxonomy. The related ObjectTags are
+    updated accordingly.
+
+    Currently only support updates the Tag value.
+    """
+    return taxonomy.cast().update_tag(tag, tag_value)

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -315,3 +315,17 @@ def autocomplete_tags(
         # remove repeats
         .distinct()
     )
+
+
+def add_tag_to_taxonomy(
+    taxonomy: Taxonomy,
+    tag: str,
+    parent_tag_id: int | None = None,
+    external_id: str | None = None
+) -> Tag:
+    """
+    Adds a new Tag to provided Taxonomy. If a Tag already exists in the
+    Taxonomy, an exception is raised, otherwise the newly created
+    Tag is returned
+    """
+    return taxonomy.cast().add_tag(tag, parent_tag_id, external_id)

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -333,3 +333,16 @@ def update_tag_in_taxonomy(taxonomy: Taxonomy, tag: int, tag_value: str):
     Currently only support updates the Tag value.
     """
     return taxonomy.cast().update_tag(tag, tag_value)
+
+
+def delete_tags_from_taxonomy(
+    taxonomy: Taxonomy,
+    tag_ids: list[Tag],
+    with_subtags: bool
+):
+    """
+    Delete Tags that belong to a Taxonomy. If any of the Tags have children and
+    the `with_subtags` is not set to `True` it will fail, otherwise
+    the sub-tags will be deleted as well.
+    """
+    return taxonomy.cast().delete_tags(tag_ids, with_subtags)

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -399,10 +399,6 @@ class Taxonomy(models.Model):
         tag = self.tag_set.get(id=tag_id)
         tag.value = tag_value
         tag.save()
-
-        # Resync all related ObjectTags to update to the new Tag value
-        object_tags = self.objecttag_set.all()
-        ObjectTag.resync_object_tags(object_tags)
         return tag
 
     def delete_tags(self, tag_ids: List[int], with_subtags: bool = False):
@@ -709,18 +705,3 @@ class ObjectTag(models.Model):
         self._value = object_tag._value  # pylint: disable=protected-access
         self._name = object_tag._name  # pylint: disable=protected-access
         return self
-
-    @classmethod
-    def resync_object_tags(cls, object_tags: models.QuerySet[ObjectTag]) -> int:
-        """
-        Reconciles ObjectTag entries with any changes made to their associated
-        taxonomies and tags. Return the number of changes made.
-        """
-        num_changed = 0
-        for object_tag in object_tags:
-            changed = object_tag.resync()
-            if changed:
-                object_tag.save()
-                num_changed += 1
-
-        return num_changed

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -370,10 +370,6 @@ class Taxonomy(models.Model):
 
         parent = None
         if parent_tag_value:
-            # Check if parent tag is valid
-            if not Tag.objects.filter(value__iexact=parent_tag_value).exists():
-                raise ValueError("Invalid `parent_tag_value` provided")
-
             # Get parent tag from taxonomy, raises Tag.DoesNotExist if doesn't
             # belong to taxonomy
             parent = self.tag_set.get(value__iexact=parent_tag_value)
@@ -401,10 +397,6 @@ class Taxonomy(models.Model):
                 "update_tag() doesn't work for system defined taxonomies. They cannot be modified."
             )
 
-        # Check if tag is valid
-        if not Tag.objects.filter(value__iexact=tag).exists():
-            raise ValueError("Invalid `tag` provided")
-
         # Update Tag instance with new value, raises Tag.DoesNotExist if
         # tag doesn't belong to taxonomy
         tag_to_update = self.tag_set.get(value__iexact=tag)
@@ -429,10 +421,6 @@ class Taxonomy(models.Model):
             raise ValueError(
                 "delete_tags() doesn't work for system defined taxonomies. They cannot be modified."
             )
-
-        # Check if tags provided are valid
-        if not Tag.objects.filter(value__in=tags).count() == len(tags):
-            raise ValueError("One or more tag in `tags` is invalid")
 
         tags_to_delete = self.tag_set.filter(value__in=tags)
 

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -347,7 +347,6 @@ class Taxonomy(models.Model):
         tag_value: str,
         parent_tag_id: int | None = None,
         external_id: str | None = None
-
     ) -> Tag:
         """
         Add new Tag to Taxonomy. If an existing Tag with the `tag_value` already

--- a/openedx_tagging/core/tagging/rest_api/v1/permissions.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/permissions.py
@@ -4,6 +4,8 @@ Tagging permissions
 import rules  # type: ignore[import]
 from rest_framework.permissions import DjangoObjectPermissions
 
+from ...models import Tag
+
 
 class TaxonomyObjectPermissions(DjangoObjectPermissions):
     """
@@ -54,4 +56,5 @@ class TagObjectPermissions(DjangoObjectPermissions):
         """
         Returns True if the user on the given request is allowed the given view for the given object.
         """
+        obj = obj.taxonomy if isinstance(obj, Tag) else obj
         return rules.has_perm("oel_tagging.list_tag", request.user, obj)

--- a/openedx_tagging/core/tagging/rest_api/v1/permissions.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/permissions.py
@@ -35,20 +35,21 @@ class ObjectTagObjectPermissions(DjangoObjectPermissions):
     }
 
 
-class TagListPermissions(DjangoObjectPermissions):
+class TagObjectPermissions(DjangoObjectPermissions):
     """
-    Permissions for Tag object views.
+    Maps each REST API methods to its corresponding Tag permission.
     """
-    def has_permission(self, request, view):
-        """
-        Returns True if the user on the given request is allowed the given view.
-        """
-        if not request.user or (
-            not request.user.is_authenticated and self.authenticated_users_only
-        ):
-            return False
-        return True
+    perms_map = {
+        "GET": ["%(app_label)s.view_%(model_name)s"],
+        "OPTIONS": [],
+        "HEAD": ["%(app_label)s.view_%(model_name)s"],
+        "POST": ["%(app_label)s.add_%(model_name)s"],
+        "PUT": ["%(app_label)s.change_%(model_name)s"],
+        "PATCH": ["%(app_label)s.change_%(model_name)s"],
+        "DELETE": ["%(app_label)s.delete_%(model_name)s"],
+    }
 
+    # This is to handle the special case for GET list of Taxonomy Tags
     def has_object_permission(self, request, view, obj):
         """
         Returns True if the user on the given request is allowed the given view for the given object.

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -110,6 +110,7 @@ class TagsSerializer(serializers.ModelSerializer):
             "value",
             "taxonomy_id",
             "parent_id",
+            "external_id",
             "sub_tags_link",
             "children_count",
         )
@@ -192,3 +193,15 @@ class TagsForSearchSerializer(TagsWithSubTagsSerializer):
         Returns the number of child tags of the given tag.
         """
         return len(obj.sub_tags)
+
+
+class TaxonomyTagCreateBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer of the body for the Taxonomy Tags CREATE view
+    """
+
+    tag = serializers.CharField(required=True)
+    parent_tag_id = serializers.PrimaryKeyRelatedField(
+        queryset=Tag.objects.all(), required=False
+    )
+    external_id = serializers.CharField(required=False)

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -120,11 +120,12 @@ class TagsSerializer(serializers.ModelSerializer):
         """
         if obj.children.count():
             query_params = f"?parent_tag_id={obj.id}"
+            request = self.context.get("request")
+            url_namespace = request.resolver_match.namespace  # get the namespace, usually "oel_tagging"
             url = (
-                reverse("oel_tagging:taxonomy-tags", args=[str(obj.taxonomy_id)])
+                reverse(f"{url_namespace}:taxonomy-tags", args=[str(obj.taxonomy_id)])
                 + query_params
             )
-            request = self.context.get("request")
             return request.build_absolute_uri(url)
         return None
 

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -205,3 +205,14 @@ class TaxonomyTagCreateBodySerializer(serializers.Serializer):  # pylint: disabl
         queryset=Tag.objects.all(), required=False
     )
     external_id = serializers.CharField(required=False)
+
+
+class TaxonomyTagUpdateBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer of the body for the Taxonomy Tags UPDATE view
+    """
+
+    tag = serializers.PrimaryKeyRelatedField(
+        queryset=Tag.objects.all(), required=True
+    )
+    tag_value = serializers.CharField(required=True)

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -197,63 +197,29 @@ class TagsForSearchSerializer(TagsWithSubTagsSerializer):
 
 class TaxonomyTagCreateBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
-    Serializer of the body for the Taxonomy Tags CREATE view
+    Serializer of the body for the Taxonomy Tags CREATE request
     """
 
     tag = serializers.CharField(required=True)
-    parent_tag_value = serializers.CharField(
-        source='parent.value', required=False
-    )
+    parent_tag_value = serializers.CharField(required=False)
     external_id = serializers.CharField(required=False)
-
-    def validate_parent_tag_value(self, value):
-        """
-        Check that the provided parent Tag exists based on the value
-        """
-        valid = Tag.objects.filter(value__iexact=value).exists()
-        if not valid:
-            raise serializers.ValidationError("Invalid `parent_tag_value` provided")
-
-        return value
 
 
 class TaxonomyTagUpdateBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
-    Serializer of the body for the Taxonomy Tags UPDATE view
+    Serializer of the body for the Taxonomy Tags UPDATE request
     """
 
-    tag = serializers.CharField(source="value", required=True)
+    tag = serializers.CharField(required=True)
     updated_tag_value = serializers.CharField(required=True)
-
-    def validate_tag(self, value):
-        """
-        Check that the provided Tag exists based on the value
-        """
-
-        valid = Tag.objects.filter(value__iexact=value).exists()
-        if not valid:
-            raise serializers.ValidationError("Invalid `tag` provided")
-
-        return value
 
 
 class TaxonomyTagDeleteBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
-    Serializer of the body for the Taxonomy Tags DELETE view
+    Serializer of the body for the Taxonomy Tags DELETE request
     """
 
     tags = serializers.ListField(
         child=serializers.CharField(), required=True
     )
     with_subtags = serializers.BooleanField(required=False)
-
-    def validate_tags(self, value):
-        """
-        Check that the provided Tags exists based on the values
-        """
-
-        valid = Tag.objects.filter(value__in=value).count() == len(value)
-        if not valid:
-            raise serializers.ValidationError("One or more tag in `tags` is invalid")
-
-        return value

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -216,3 +216,16 @@ class TaxonomyTagUpdateBodySerializer(serializers.Serializer):  # pylint: disabl
         queryset=Tag.objects.all(), required=True
     )
     tag_value = serializers.CharField(required=True)
+
+
+class TaxonomyTagDeleteBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer of the body for the Taxonomy Tags DELETE view
+    """
+
+    tag_ids = serializers.PrimaryKeyRelatedField(
+        queryset=Tag.objects.all(),
+        many=True,
+        required=True
+    )
+    with_subtags = serializers.BooleanField(required=False)

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -15,6 +15,7 @@ from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from openedx_tagging.core.tagging.models.base import Tag
 
 from ...api import (
+    TagDoesNotExist,
     add_tag_to_taxonomy,
     create_taxonomy,
     delete_tags_from_taxonomy,
@@ -401,7 +402,7 @@ class ObjectTagView(
         tags = body.data.get("tags", [])
         try:
             tag_object(taxonomy, tags, object_id)
-        except Tag.DoesNotExist as e:
+        except TagDoesNotExist as e:
             raise ValidationError from e
         except ValueError as e:
             raise ValidationError from e
@@ -677,7 +678,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
             new_tag = add_tag_to_taxonomy(
                 taxonomy, tag, parent_tag_id, external_id
             )
-        except Tag.DoesNotExist as e:
+        except TagDoesNotExist as e:
             raise Http404("Parent Tag not found") from e
         except ValueError as e:
             raise ValidationError(e) from e
@@ -704,7 +705,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
 
         try:
             updated_tag = update_tag_in_taxonomy(taxonomy, tag, tag_value)
-        except Tag.DoesNotExist as e:
+        except TagDoesNotExist as e:
             raise Http404("Tag not found") from e
         except ValueError as e:
             raise ValidationError(e) from e

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -416,14 +416,14 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
     View to list/create/update/delete tags of a taxonomy.
 
     **List Query Parameters**
-        * pk (required) - The pk of the taxonomy to retrieve tags.
+        * id (required) - The ID of the taxonomy to retrieve tags.
         * parent_tag_id (optional) - Id of the tag to retrieve children tags.
         * page (optional) - Page number (default: 1)
         * page_size (optional) - Number of items per page (default: 10)
 
     **List Example Requests**
-        GET api/tagging/v1/taxonomy/:pk/tags                                        - Get tags of taxonomy
-        GET api/tagging/v1/taxonomy/:pk/tags?parent_tag_id=30                       - Get children tags of tag
+        GET api/tagging/v1/taxonomy/:id/tags                                        - Get tags of taxonomy
+        GET api/tagging/v1/taxonomy/:id/tags?parent_tag_id=30                       - Get children tags of tag
 
     **List Query Returns**
         * 200 - Success
@@ -432,7 +432,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         * 404 - Taxonomy not found
 
     **Create Query Parameters**
-        * pk (required) - The pk of the taxonomy to create a Tag for
+        * id (required) - The ID of the taxonomy to create a Tag for
 
     **Create Request Body**
         * tag (required): The value of the Tag that should be added to
@@ -442,7 +442,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         * extenal_id (optional): The external id for the new Tag
 
     **Create Example Requests**
-        POST api/tagging/v1/taxonomy/:pk/tags                                       - Create a Tag in taxonomy
+        POST api/tagging/v1/taxonomy/:id/tags                                       - Create a Tag in taxonomy
         {
             "value": "New Tag",
             "parent_tag_value": "Parent Tag"
@@ -456,19 +456,14 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         * 404 - Taxonomy not found
 
     **Update Query Parameters**
-        * pk (required) - The pk of the taxonomy to update a Tag in
+        * id (required) - The ID of the taxonomy to update a Tag in
 
     **Update Request Body**
         * tag (required): The value (identifier) of the Tag to be updated
         * updated_tag_value (required): The updated value of the Tag
 
     **Update Example Requests**
-        PUT api/tagging/v1/taxonomy/:pk/tags                                        - Update a Tag in Taxonomy
-        {
-            "tag": "Tag 1",
-            "updated_tag_value": "Updated Tag Value"
-        }
-        PATCH api/tagging/v1/taxonomy/:pk/tags                                      - Update a Tag in Taxonomy
+        PATCH api/tagging/v1/taxonomy/:id/tags                                      - Update a Tag in Taxonomy
         {
             "tag": "Tag 1",
             "updated_tag_value": "Updated Tag Value"
@@ -481,7 +476,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         * 404 - Taxonomy, Tag or Parent Tag not found
 
     **Delete Query Parameters**
-        * pk (required) - The pk of the taxonomy to Delete Tag(s) in
+        * id (required) - The ID of the taxonomy to Delete Tag(s) in
 
     **Delete Request Body**
         * tags (required): The values (identifiers) of Tags that should be
@@ -491,7 +486,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
                                    set to `True`. Defaults to `False`.
 
     **Delete Example Requests**
-        DELETE api/tagging/v1/taxonomy/:pk/tags                                     - Delete Tag(s) in Taxonomy
+        DELETE api/tagging/v1/taxonomy/:id/tags                                     - Delete Tag(s) in Taxonomy
         {
             "tags": ["Tag 1", "Tag 2", "Tag 3"],
             "with_subtags": True

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -437,7 +437,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
     **Create Request Body**
         * tag (required): The value of the Tag that should be added to
           the Taxonomy
-        * parent_tag_id (optional): The id of the parent tag that the new
+        * parent_tag_value (optional): The value of the parent tag that the new
           Tag should fall under
         * extenal_id (optional): The external id for the new Tag
 
@@ -445,7 +445,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         POST api/tagging/v1/taxonomy/:pk/tags                                       - Create a Tag in taxonomy
         {
             "value": "New Tag",
-            "parent_tag_id": 123
+            "parent_tag_value": "Parent Tag"
             "external_id": "abc123",
         }
 
@@ -459,19 +459,19 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         * pk (required) - The pk of the taxonomy to update a Tag in
 
     **Update Request Body**
-        * tag (required): The ID of the Tag that should be updated
-        * tag_value (required): The updated value of the Tag
+        * tag (required): The value (identifier) of the Tag to be updated
+        * updated_tag_value (required): The updated value of the Tag
 
     **Update Example Requests**
         PUT api/tagging/v1/taxonomy/:pk/tags                                        - Update a Tag in Taxonomy
         {
-            "tag": 1,
-            "tag_value": "Updated Tag Value"
+            "tag": "Tag 1",
+            "updated_tag_value": "Updated Tag Value"
         }
         PATCH api/tagging/v1/taxonomy/:pk/tags                                      - Update a Tag in Taxonomy
         {
-            "tag": 1,
-            "tag_value": "Updated Tag Value"
+            "tag": "Tag 1",
+            "updated_tag_value": "Updated Tag Value"
         }
 
     **Update Query Returns**
@@ -484,7 +484,8 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         * pk (required) - The pk of the taxonomy to Delete Tag(s) in
 
     **Delete Request Body**
-        * tag_ids (required): The IDs of Tags that should be deleted from Taxonomy
+        * tags (required): The values (identifiers) of Tags that should be
+                           deleted from Taxonomy
         * with_subtags (optional): If a Tag in the provided ids contains
                                    children (subtags), deletion will fail unless
                                    set to `True`. Defaults to `False`.
@@ -492,7 +493,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
     **Delete Example Requests**
         DELETE api/tagging/v1/taxonomy/:pk/tags                                     - Delete Tag(s) in Taxonomy
         {
-            "tag_ids": [1,2,3],
+            "tags": ["Tag 1", "Tag 2", "Tag 3"],
             "with_subtags": True
         }
 
@@ -687,12 +688,12 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         body.is_valid(raise_exception=True)
 
         tag = body.data.get("tag")
-        parent_tag_id = body.data.get("parent_tag_id", None)
+        parent_tag_value = body.data.get("parent_tag_value", None)
         external_id = body.data.get("external_id", None)
 
         try:
             new_tag = add_tag_to_taxonomy(
-                taxonomy, tag, parent_tag_id, external_id
+                taxonomy, tag, parent_tag_value, external_id
             )
         except TagDoesNotExist as e:
             raise Http404("Parent Tag not found") from e
@@ -718,10 +719,10 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         body.is_valid(raise_exception=True)
 
         tag = body.data.get("tag")
-        tag_value = body.data.get("tag_value")
+        updated_tag_value = body.data.get("updated_tag_value")
 
         try:
-            updated_tag = update_tag_in_taxonomy(taxonomy, tag, tag_value)
+            updated_tag = update_tag_in_taxonomy(taxonomy, tag, updated_tag_value)
         except TagDoesNotExist as e:
             raise Http404("Tag not found") from e
         except ValueError as e:
@@ -746,11 +747,11 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         body = TaxonomyTagDeleteBodySerializer(data=request.data)
         body.is_valid(raise_exception=True)
 
-        tag_ids = body.data.get("tag_ids")
+        tags = body.data.get("tags")
         with_subtags = body.data.get("with_subtags")
 
         try:
-            delete_tags_from_taxonomy(taxonomy, tag_ids, with_subtags)
+            delete_tags_from_taxonomy(taxonomy, tags, with_subtags)
         except ValueError as e:
             raise ValidationError(e) from e
 

--- a/openedx_tagging/core/tagging/rules.py
+++ b/openedx_tagging/core/tagging/rules.py
@@ -57,11 +57,10 @@ def can_view_tag(user: UserType, tag: Tag | None = None) -> bool:
     User can view tags for any taxonomy they can view.
     """
     taxonomy = tag.taxonomy.cast() if (tag and tag.taxonomy) else None
-    has_perm_thing = user.has_perm(
+    return user.has_perm(
         "oel_tagging.view_taxonomy",
         taxonomy,
     )
-    return has_perm_thing
 
 
 @rules.predicate

--- a/tests/openedx_tagging/core/tagging/test_rules.py
+++ b/tests/openedx_tagging/core/tagging/test_rules.py
@@ -141,12 +141,12 @@ class TestRulesTagging(TestTagTaxonomyMixin, TestCase):
     )
     def test_tag_free_text_taxonomy(self, perm):
         """
-        Taxonomy administrators cannot modify tags on a free-text Taxonomy
+        Taxonomy administrators can modify any Tag, even those associated with a free-text Taxonomy
         """
         self.taxonomy.allow_free_text = True
         self.taxonomy.save()
         assert self.superuser.has_perm(perm, self.bacteria)
-        assert not self.staff.has_perm(perm, self.bacteria)
+        assert self.staff.has_perm(perm, self.bacteria)
         assert not self.learner.has_perm(perm, self.bacteria)
 
     @ddt.data(

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1210,6 +1210,19 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert data.get("num_pages") == 2
         assert data.get("current_page") == 2
 
+    def test_create_tag_in_taxonomy_while_loggedout(self):
+        new_tag_value = "New Tag"
+
+        create_data = {
+            "tag": new_tag_value
+        }
+
+        response = self.client.post(
+            self.small_taxonomy_url, create_data, format="json"
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
     def test_create_tag_in_taxonomy(self):
         self.client.force_authenticate(user=self.user)
         new_tag_value = "New Tag"
@@ -1365,6 +1378,24 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_tag_in_taxonomy_while_loggedout(self):
+        updated_tag_value = "Updated Tag"
+
+        # Existing Tag that will be updated
+        existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
+
+        update_data = {
+            "tag": existing_tag.id,
+            "tag_value": updated_tag_value
+        }
+
+        # Test updating using the PUT method
+        response = self.client.put(
+            self.small_taxonomy_url, update_data, format="json"
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_update_tag_in_taxonomy_with_different_methods(self):
         self.client.force_authenticate(user=self.user)
@@ -1527,6 +1558,21 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_single_tag_from_taxonomy_while_loggedout(self):
+        # Get Tag that will be deleted
+        existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
+
+        delete_data = {
+            "tag_ids": [existing_tag.id],
+            "with_subtags": True
+        }
+
+        response = self.client.delete(
+            self.small_taxonomy_url, delete_data, format="json"
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_delete_single_tag_from_taxonomy(self):
         self.client.force_authenticate(user=self.user)

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1223,8 +1223,22 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_create_tag_in_taxonomy(self):
+    def test_create_tag_in_taxonomy_without_permission(self):
         self.client.force_authenticate(user=self.user)
+        new_tag_value = "New Tag"
+
+        create_data = {
+            "tag": new_tag_value
+        }
+
+        response = self.client.post(
+            self.small_taxonomy_url, create_data, format="json"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_create_tag_in_taxonomy(self):
+        self.client.force_authenticate(user=self.staff)
         new_tag_value = "New Tag"
 
         create_data = {
@@ -1248,7 +1262,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         self.assertEqual(data.get("children_count"), 0)
 
     def test_create_tag_in_taxonomy_with_parent_id(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         parent_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
         new_tag_value = "New Child Tag"
         new_external_id = "extId"
@@ -1276,7 +1290,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         self.assertEqual(data.get("children_count"), 0)
 
     def test_create_tag_in_invalid_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         new_tag_value = "New Tag"
 
         create_data = {
@@ -1291,7 +1305,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_create_tag_in_free_text_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         new_tag_value = "New Tag"
 
         create_data = {
@@ -1309,7 +1323,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_create_tag_in_system_defined_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         new_tag_value = "New Tag"
 
         create_data = {
@@ -1327,7 +1341,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_create_tag_in_taxonomy_with_invalid_parent_tag_id(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         invalid_parent_tag_id = 91919
         new_tag_value = "New Child Tag"
 
@@ -1343,7 +1357,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_create_tag_in_taxonomy_with_parent_tag_id_in_other_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         invalid_parent_tag_id = 1
         new_tag_value = "New Child Tag"
 
@@ -1359,7 +1373,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_create_tag_in_taxonomy_with_already_existing_value(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         new_tag_value = "New Tag"
 
         create_data = {
@@ -1397,8 +1411,27 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_update_tag_in_taxonomy_with_different_methods(self):
+    def test_update_tag_in_taxonomy_without_permission(self):
         self.client.force_authenticate(user=self.user)
+        updated_tag_value = "Updated Tag"
+
+        # Existing Tag that will be updated
+        existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
+
+        update_data = {
+            "tag": existing_tag.id,
+            "tag_value": updated_tag_value
+        }
+
+        # Test updating using the PUT method
+        response = self.client.put(
+            self.small_taxonomy_url, update_data, format="json"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_update_tag_in_taxonomy_with_different_methods(self):
+        self.client.force_authenticate(user=self.staff)
         updated_tag_value = "Updated Tag"
         updated_tag_value_2 = "Updated Tag 2"
 
@@ -1444,7 +1477,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         self.assertEqual(data.get("external_id"), existing_tag.external_id)
 
     def test_update_tag_in_taxonomy_reflects_changes_in_object_tags(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
@@ -1495,7 +1528,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         self.assertEqual(object_tag_3.value, updated_tag_value)
 
     def test_update_tag_in_taxonomy_with_invalid_tag_id(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         updated_tag_value = "Updated Tag"
 
         update_data = {
@@ -1510,7 +1543,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_tag_in_taxonomy_with_tag_id_in_other_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
         updated_tag_value = "Updated Tag"
 
         update_data = {
@@ -1525,7 +1558,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_update_tag_in_taxonomy_with_no_tag_value_provided(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Existing Tag that will be updated
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
@@ -1541,7 +1574,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_update_tag_in_invalid_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Existing Tag that will be updated
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
@@ -1574,8 +1607,24 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_delete_single_tag_from_taxonomy(self):
+    def test_delete_single_tag_from_taxonomy_without_permission(self):
         self.client.force_authenticate(user=self.user)
+        # Get Tag that will be deleted
+        existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
+
+        delete_data = {
+            "tag_ids": [existing_tag.id],
+            "with_subtags": True
+        }
+
+        response = self.client.delete(
+            self.small_taxonomy_url, delete_data, format="json"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_delete_single_tag_from_taxonomy(self):
+        self.client.force_authenticate(user=self.staff)
 
         # Get Tag that will be deleted
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
@@ -1596,7 +1645,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
             existing_tag.refresh_from_db()
 
     def test_delete_multiple_tags_from_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Get Tags that will be deleted
         existing_tags = self.small_taxonomy.tag_set.filter(parent=None)[:3]
@@ -1618,7 +1667,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
                 existing_tag.refresh_from_db()
 
     def test_delete_tag_with_subtags_should_fail_without_flag_passed(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Get Tag that will be deleted
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
@@ -1634,7 +1683,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_delete_tag_in_invalid_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Get Tag that will be deleted
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
@@ -1651,7 +1700,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_delete_tag_in_taxonomy_with_invalid_tag_id(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         delete_data = {
             "tag_ids": [91919]
@@ -1664,7 +1713,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_delete_tag_with_tag_id_in_other_taxonomy(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Get Tag in other Taxonomy
         tag_in_other_taxonomy = self.small_taxonomy.tag_set.filter(parent=None).first()
@@ -1680,7 +1729,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_delete_tag_in_taxonomy_without_subtags(self):
-        self.client.force_authenticate(user=self.user)
+        self.client.force_authenticate(user=self.staff)
 
         # Get Tag that will be deleted
         existing_tag = self.small_taxonomy.tag_set.filter(children__isnull=True).first()

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1354,7 +1354,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
             self.small_taxonomy_url, create_data, format="json"
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_create_tag_in_taxonomy_with_parent_tag_in_other_taxonomy(self):
         self.client.force_authenticate(user=self.staff)
@@ -1541,7 +1541,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
             self.small_taxonomy_url, update_data, format="json"
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_update_tag_in_taxonomy_with_tag_in_other_taxonomy(self):
         self.client.force_authenticate(user=self.staff)

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1261,7 +1261,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         self.assertIsNone(data.get("sub_tags_link"))
         self.assertEqual(data.get("children_count"), 0)
 
-    def test_create_tag_in_taxonomy_with_parent_id(self):
+    def test_create_tag_in_taxonomy_with_parent(self):
         self.client.force_authenticate(user=self.staff)
         parent_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
         new_tag_value = "New Child Tag"
@@ -1269,7 +1269,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         create_data = {
             "tag": new_tag_value,
-            "parent_tag_id": parent_tag.id,
+            "parent_tag_value": parent_tag.value,
             "external_id": new_external_id
         }
 
@@ -1340,14 +1340,14 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_create_tag_in_taxonomy_with_invalid_parent_tag_id(self):
+    def test_create_tag_in_taxonomy_with_invalid_parent_tag(self):
         self.client.force_authenticate(user=self.staff)
-        invalid_parent_tag_id = 91919
+        invalid_parent_tag = "Invalid Tag"
         new_tag_value = "New Child Tag"
 
         create_data = {
             "tag": new_tag_value,
-            "parent_tag_id": invalid_parent_tag_id,
+            "parent_tag_value": invalid_parent_tag,
         }
 
         response = self.client.post(
@@ -1356,14 +1356,14 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_create_tag_in_taxonomy_with_parent_tag_id_in_other_taxonomy(self):
+    def test_create_tag_in_taxonomy_with_parent_tag_in_other_taxonomy(self):
         self.client.force_authenticate(user=self.staff)
-        invalid_parent_tag_id = 1
+        tag_in_other_taxonomy = Tag.objects.get(id=1)
         new_tag_value = "New Child Tag"
 
         create_data = {
             "tag": new_tag_value,
-            "parent_tag_id": invalid_parent_tag_id,
+            "parent_tag_value": tag_in_other_taxonomy.value,
         }
 
         response = self.client.post(
@@ -1400,8 +1400,8 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         update_data = {
-            "tag": existing_tag.id,
-            "tag_value": updated_tag_value
+            "tag": existing_tag.value,
+            "updated_tag_value": updated_tag_value
         }
 
         # Test updating using the PUT method
@@ -1419,8 +1419,8 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         update_data = {
-            "tag": existing_tag.id,
-            "tag_value": updated_tag_value
+            "tag": existing_tag.value,
+            "updated_tag_value": updated_tag_value
         }
 
         # Test updating using the PUT method
@@ -1439,8 +1439,8 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         update_data = {
-            "tag": existing_tag.id,
-            "tag_value": updated_tag_value
+            "tag": existing_tag.value,
+            "updated_tag_value": updated_tag_value
         }
 
         # Test updating using the PUT method
@@ -1460,7 +1460,8 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         self.assertEqual(data.get("external_id"), existing_tag.external_id)
 
         # Test updating using the PATCH method
-        update_data["tag_value"] = updated_tag_value_2
+        update_data["tag"] = updated_tag_value  # Since the value changed
+        update_data["updated_tag_value"] = updated_tag_value_2
         response = self.client.patch(
             self.small_taxonomy_url, update_data, format="json"
         )
@@ -1499,8 +1500,8 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         updated_tag_value = "Updated Tag"
         update_data = {
-            "tag": existing_tag.id,
-            "tag_value": updated_tag_value
+            "tag": existing_tag.value,
+            "updated_tag_value": updated_tag_value
         }
 
         # Test updating using the PUT method
@@ -1527,13 +1528,13 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         object_tag_3.refresh_from_db()
         self.assertEqual(object_tag_3.value, updated_tag_value)
 
-    def test_update_tag_in_taxonomy_with_invalid_tag_id(self):
+    def test_update_tag_in_taxonomy_with_invalid_tag(self):
         self.client.force_authenticate(user=self.staff)
         updated_tag_value = "Updated Tag"
 
         update_data = {
             "tag": 919191,
-            "tag_value": updated_tag_value
+            "updated_tag_value": updated_tag_value
         }
 
         response = self.client.put(
@@ -1542,13 +1543,14 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_update_tag_in_taxonomy_with_tag_id_in_other_taxonomy(self):
+    def test_update_tag_in_taxonomy_with_tag_in_other_taxonomy(self):
         self.client.force_authenticate(user=self.staff)
         updated_tag_value = "Updated Tag"
+        tag_in_other_taxonomy = Tag.objects.get(id=1)
 
         update_data = {
-            "tag": 1,
-            "tag_value": updated_tag_value
+            "tag": tag_in_other_taxonomy.value,
+            "updated_tag_value": updated_tag_value
         }
 
         response = self.client.put(
@@ -1564,7 +1566,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         update_data = {
-            "tag": existing_tag.id
+            "tag": existing_tag.value
         }
 
         response = self.client.put(
@@ -1581,8 +1583,8 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         updated_tag_value = "Updated Tag"
         update_data = {
-            "tag": existing_tag.id,
-            "tag_value": updated_tag_value
+            "tag": existing_tag.value,
+            "updated_tag_value": updated_tag_value
         }
 
         invalid_taxonomy_url = TAXONOMY_TAGS_URL.format(pk=919191)
@@ -1597,7 +1599,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         delete_data = {
-            "tag_ids": [existing_tag.id],
+            "tags": [existing_tag.value],
             "with_subtags": True
         }
 
@@ -1613,7 +1615,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         delete_data = {
-            "tag_ids": [existing_tag.id],
+            "tags": [existing_tag.value],
             "with_subtags": True
         }
 
@@ -1630,7 +1632,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         delete_data = {
-            "tag_ids": [existing_tag.id],
+            "tags": [existing_tag.value],
             "with_subtags": True
         }
 
@@ -1651,7 +1653,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tags = self.small_taxonomy.tag_set.filter(parent=None)[:3]
 
         delete_data = {
-            "tag_ids": [existing_tag.id for existing_tag in existing_tags],
+            "tags": [existing_tag.value for existing_tag in existing_tags],
             "with_subtags": True
         }
 
@@ -1673,7 +1675,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         delete_data = {
-            "tag_ids": [existing_tag.id]
+            "tags": [existing_tag.value]
         }
 
         response = self.client.delete(
@@ -1689,7 +1691,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         delete_data = {
-            "tag_ids": [existing_tag.id]
+            "tags": [existing_tag.value]
         }
 
         invalid_taxonomy_url = TAXONOMY_TAGS_URL.format(pk=919191)
@@ -1699,11 +1701,11 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_delete_tag_in_taxonomy_with_invalid_tag_id(self):
+    def test_delete_tag_in_taxonomy_with_invalid_tag(self):
         self.client.force_authenticate(user=self.staff)
 
         delete_data = {
-            "tag_ids": [91919]
+            "tags": ["Invalid Tag"]
         }
 
         response = self.client.delete(
@@ -1712,14 +1714,14 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_delete_tag_with_tag_id_in_other_taxonomy(self):
+    def test_delete_tag_with_tag_in_other_taxonomy(self):
         self.client.force_authenticate(user=self.staff)
 
         # Get Tag in other Taxonomy
         tag_in_other_taxonomy = self.small_taxonomy.tag_set.filter(parent=None).first()
 
         delete_data = {
-            "tag_ids": [tag_in_other_taxonomy.id]
+            "tags": [tag_in_other_taxonomy.value]
         }
 
         response = self.client.delete(
@@ -1735,7 +1737,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         existing_tag = self.small_taxonomy.tag_set.filter(children__isnull=True).first()
 
         delete_data = {
-            "tag_ids": [existing_tag.id]
+            "tags": [existing_tag.value]
         }
 
         response = self.client.delete(


### PR DESCRIPTION
### Description

This PR introduces the CRUD python and REST APIs for interacting with Taxonomy Tags. Creating, updating and deleting them.

### Supporting Information

Related Tickets:
- Closes https://github.com/openedx/modular-learning/issues/136

### Testing Instructions

Make sure all the tests pass, and they cover all the cases.

---
Private-ref: [FAL-3519](https://tasks.opencraft.com/browse/FAL-3519)
