### PR TITLE
feat: add export taxonomy rest api

### DIFF
--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -16,6 +16,14 @@ class TaxonomyListQueryParamsSerializer(serializers.Serializer):  # pylint: disa
     enabled = serializers.BooleanField(required=False)
 
 
+class TaxonomyExportQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for the query params for the GET view
+    """
+    download = serializers.BooleanField(required=False, default=False)
+    output_format = serializers.RegexField(r"(?i)^(json|csv)$", allow_blank=False)
+
+
 class TaxonomySerializer(serializers.ModelSerializer):
     class Meta:
         model = Taxonomy

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -4,8 +4,9 @@ Tagging API Views
 from __future__ import annotations
 
 from django.db import models
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from rest_framework import mixins
+from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed, PermissionDenied, ValidationError
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
@@ -23,6 +24,8 @@ from ...api import (
     search_tags,
     tag_object,
 )
+from ...import_export.api import export_tags
+from ...import_export.parsers import ParserFormat
 from ...models import Taxonomy
 from ...rules import ChangeObjectTagPermissionItem
 from ..paginators import SEARCH_TAGS_THRESHOLD, TAGS_THRESHOLD, DisabledTagsPagination, TagsPagination
@@ -35,6 +38,7 @@ from .serializers import (
     TagsForSearchSerializer,
     TagsSerializer,
     TagsWithSubTagsSerializer,
+    TaxonomyExportQueryParamsSerializer,
     TaxonomyListQueryParamsSerializer,
     TaxonomySerializer,
 )
@@ -42,7 +46,7 @@ from .serializers import (
 
 class TaxonomyView(ModelViewSet):
     """
-    View to list, create, retrieve, update, or delete Taxonomies.
+    View to list, create, retrieve, update, delete or export Taxonomies.
 
     **List Query Parameters**
         * enabled (optional) - Filter by enabled status. Valid values: true,
@@ -141,6 +145,23 @@ class TaxonomyView(ModelViewSet):
         * 404 - Taxonomy not found
         * 403 - Permission denied
 
+    **Export Query Parameters**
+        * output_format - Define the output format. Valid values: json, csv
+        * download (optional) - Add headers on the response to let the browser
+          automatically download the file.
+
+    **Export Example Requests**
+        GET api/tagging/v1/taxonomy/:pk/export?output_format=csv                - Export taxonomy as CSV
+        GET api/tagging/v1/taxonomy/:pk/export?output_format=json               - Export taxonomy as JSON
+        GET api/tagging/v1/taxonomy/:pk/export?output_format=csv&download=1     - Export and downloads taxonomy as CSV
+        GET api/tagging/v1/taxonomy/:pk/export?output_format=json&download=1    - Export and downloads taxonomy as JSON
+
+    **Export Query Returns**
+        * 200 - Success
+        * 400 - Invalid query parameter
+        * 403 - Permission denied
+
+
     """
 
     serializer_class = TaxonomySerializer
@@ -180,6 +201,39 @@ class TaxonomyView(ModelViewSet):
         Create a new taxonomy.
         """
         serializer.instance = create_taxonomy(**serializer.validated_data)
+
+    @action(detail=True, methods=["get"])
+    def export(self, request, **_kwargs) -> HttpResponse:
+        """
+        Export a taxonomy.
+        """
+        taxonomy = self.get_object()
+        perm = "oel_tagging.export_taxonomy"
+        if not request.user.has_perm(perm, taxonomy):
+            raise PermissionDenied("You do not have permission to export this taxonomy.")
+        query_params = TaxonomyExportQueryParamsSerializer(
+            data=request.query_params.dict()
+        )
+        query_params.is_valid(raise_exception=True)
+        output_format = query_params.data.get("output_format")
+        assert output_format is not None
+        if output_format.lower() == "json":
+            parser_format = ParserFormat.JSON
+            content_type = "application/json"
+        else:
+            parser_format = ParserFormat.CSV
+            if query_params.data.get("download"):
+                content_type = "text/csv"
+            else:
+                content_type = "text"
+
+        tags = export_tags(taxonomy, parser_format)
+        if query_params.data.get("download"):
+            response = HttpResponse(tags.encode('utf-8'), content_type=content_type)
+            response["Content-Disposition"] = f'attachment; filename="{taxonomy.name}{parser_format.value}"'
+            return response
+
+        return HttpResponse(tags, content_type=content_type)
 
 
 class ObjectTagView(

--- a/openedx_tagging/core/tagging/rules.py
+++ b/openedx_tagging/core/tagging/rules.py
@@ -109,6 +109,7 @@ rules.add_perm("oel_tagging.add_taxonomy", can_change_taxonomy)
 rules.add_perm("oel_tagging.change_taxonomy", can_change_taxonomy)
 rules.add_perm("oel_tagging.delete_taxonomy", can_change_taxonomy)
 rules.add_perm("oel_tagging.view_taxonomy", can_view_taxonomy)
+rules.add_perm("oel_tagging.export_taxonomy", can_view_taxonomy)
 
 # Tag
 rules.add_perm("oel_tagging.add_tag", can_change_tag)


### PR DESCRIPTION
## Description
Add a new action to allow exporting a single Taxonomy

## Supporting Information
- https://github.com/openedx/modular-learning/issues/113
 
## Testing instructions
1. Please ensure that the tests cover the expected behavior of the view
2.  Using this branch, run the dev server: `python manage.py runserver`
3. Create a superuser using `python manage.py createsuperuser`
5. Login in admin and authenticate with the user created (http://127.0.0.1:8000/admin)
6. In the same browser session, check the result in the API Viewer:
    - http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/-1/export/?output_format=csv
    - http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/-1/export/?output_format=json
7. In the same browser session, check if the API also downloads the file with the correct filename:
    - http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/-1/export/?output_format=csv&download=1
    - http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/-1/export/?output_format=json&download=1

## Before Merge
- [ ] Bump version
____
Private-ref: [FAL-3521](https://tasks.opencraft.com/browse/FAL-3521)