### PR TITLE
fix: add `lookup_value_regex` for taxonomy rest api

### DIFF
--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -166,6 +166,7 @@ class TaxonomyView(ModelViewSet):
 
     """
 
+    lookup_value_regex = r"\d+"
     serializer_class = TaxonomySerializer
     permission_classes = [TaxonomyObjectPermissions]
 

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -195,6 +195,13 @@ class TestTaxonomyViewSet(TestTaxonomyViewMixin):
         response = self.client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_detail_taxonomy_invalud_pk(self) -> None:
+        url = TAXONOMY_DETAIL_URL.format(pk="invalid")
+
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     @ddt.data(
         (None, status.HTTP_401_UNAUTHORIZED),
         ("user", status.HTTP_403_FORBIDDEN),


### PR DESCRIPTION
## Description
Configure the `lookup_value_regex` in the TaxonomyView. Currently, accessing the API using an invalid pk (i.e. using a `str`) throws an exception when the value is converted to `int`, returning status `500`, instead of a `404`.
 
## Testing instructions
1. Please ensure that the tests cover the expected behavior of the view
2.  Using this branch, run the dev server: `python manage.py runserver`
3. Create a superuser using `python manage.py createsuperuser`
5. Login in admin and authenticate with the user created (http://127.0.0.1:8000/admin)
6. In the same browser session, check the result in the API Viewer:
    - http://127.0.0.1:8000/tagging/rest_api/v1/taxonomies/invalid_pk (should return 404)
____
Private-ref: [FAL-3529](https://tasks.opencraft.com/browse/FAL-3529)