### PR TITLE
fix: allow export of system defined and open taxonomies

### DIFF
--- a/openedx_tagging/core/tagging/import_export/api.py
+++ b/openedx_tagging/core/tagging/import_export/api.py
@@ -75,7 +75,7 @@ def import_tags(
     in the file (regardless of action), then `tag_2` and `tag_3` will be deleted
     if `replace=True`
     """
-    _import_export_validations(taxonomy)
+    _import_validations(taxonomy)
 
     # Checks that exists only one task import in progress at a time per taxonomy
     if not _check_unique_import_task(taxonomy):
@@ -146,7 +146,6 @@ def export_tags(taxonomy: Taxonomy, output_format: ParserFormat) -> str:
     """
     Returns a string with all tag data of the given taxonomy
     """
-    _import_export_validations(taxonomy)
     parser = get_parser(output_format)
     return parser.export(taxonomy)
 
@@ -178,7 +177,7 @@ def _get_last_import_task(taxonomy: Taxonomy) -> TagImportTask | None:
     )
 
 
-def _import_export_validations(taxonomy: Taxonomy):
+def _import_validations(taxonomy: Taxonomy):
     """
     Validates if the taxonomy is allowed to import or export tags
     """
@@ -186,12 +185,12 @@ def _import_export_validations(taxonomy: Taxonomy):
     if taxonomy.allow_free_text:
         raise NotImplementedError(
             _(
-                "Import/export for free-form taxonomies will be implemented in the future."
+                "Import for free-form taxonomies will be implemented in the future."
             )
         )
     if taxonomy.system_defined:
         raise ValueError(
             _(
-                "Invalid taxonomy ({id}): You cannot import/export a system-defined taxonomy."
+                "Invalid taxonomy ({id}): You cannot import a system-defined taxonomy."
             ).format(id=taxonomy.id)
         )

--- a/openedx_tagging/core/tagging/import_export/api.py
+++ b/openedx_tagging/core/tagging/import_export/api.py
@@ -179,15 +179,16 @@ def _get_last_import_task(taxonomy: Taxonomy) -> TagImportTask | None:
 
 def _import_validations(taxonomy: Taxonomy):
     """
-    Validates if the taxonomy is allowed to import or export tags
+    Validates if the taxonomy is allowed to import tags
     """
     taxonomy = taxonomy.cast()
     if taxonomy.allow_free_text:
-        raise NotImplementedError(
+        raise ValueError(
             _(
-                "Import for free-form taxonomies will be implemented in the future."
-            )
+                "Invalid taxonomy ({id}): You cannot import a free-form taxonomy."
+            ).format(id=taxonomy.id)
         )
+
     if taxonomy.system_defined:
         raise ValueError(
             _(

--- a/tests/openedx_tagging/core/tagging/import_export/test_api.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_api.py
@@ -174,21 +174,6 @@ class TestImportExportApi(TestImportExportMixin, TestCase):
             self.parser_format,
         )
 
-    def test_export_validations(self) -> None:
-        # Check that import is invalid with open taxonomy
-        with self.assertRaises(NotImplementedError):
-            import_export_api.export_tags(
-                self.open_taxonomy,
-                self.parser_format,
-            )
-
-        # Check that import is invalid with system taxonomy
-        with self.assertRaises(ValueError):
-            import_export_api.export_tags(
-                self.system_taxonomy,
-                self.parser_format,
-            )
-
     def test_import_with_export_output(self) -> None:
         for parser_format in ParserFormat:
             output = import_export_api.export_tags(

--- a/tests/openedx_tagging/core/tagging/import_export/test_api.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_api.py
@@ -74,7 +74,7 @@ class TestImportExportApi(TestImportExportMixin, TestCase):
 
     def test_import_export_validations(self) -> None:
         # Check that import is invalid with open taxonomy
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(ValueError):
             import_export_api.import_tags(
                 self.open_taxonomy,
                 self.file,


### PR DESCRIPTION
## Description
Small fix to allow api calls to EXPORT taxonomies with `system_defined=True` and `allow_free_text=True`.
The IMPORT restrictions where not changed.

___
Private-ref: [FAL-3528](https://tasks.opencraft.com/browse/FAL-3528)