### PR TITLE
Python API to get tag counts, ignore deleted/disabled ObjectTags by default [FC-0036]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -673,3 +673,21 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
             # "Bacteria (children: 2)",  # does not contain "cha" but a child does
             # "  Archaebacteria (children: 0)",
         ]
+
+    def test_get_object_tag_counts(self) -> None:
+        """
+        Smoke test of get_object_tag_counts
+        """
+        obj1 = "object_id1"
+        obj2 = "object_id2"
+        other = "other_object"
+        # Give each object 1-2 tags:
+        tagging_api.tag_object(object_id=obj1, taxonomy=self.taxonomy, tags=["DPANN"])
+        tagging_api.tag_object(object_id=obj2, taxonomy=self.taxonomy, tags=["Chordata"])
+        tagging_api.tag_object(object_id=obj2, taxonomy=self.free_text_taxonomy, tags=["has a notochord"])
+        tagging_api.tag_object(object_id=other, taxonomy=self.free_text_taxonomy, tags=["other"])
+
+        assert tagging_api.get_object_tag_counts(obj1) == {obj1: 1}
+        assert tagging_api.get_object_tag_counts(obj2) == {obj2: 2}
+        assert tagging_api.get_object_tag_counts(f"{obj1},{obj2}") == {obj1: 1, obj2: 2}
+        assert tagging_api.get_object_tag_counts("object_*") == {obj1: 1, obj2: 2}

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -766,7 +766,7 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
         api.tag_object(self.free_text_taxonomy, ["foo", "bar", "tribble"], object_id)  # Free text tags
 
         # At first, none of these will be deleted:
-        assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id)] == [
+        assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id, include_deleted=True)] == [
             ("bar", False),
             ("foo", False),
             ("tribble", False),
@@ -777,7 +777,7 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
         # Delete "bacteria" from the taxonomy:
         api.delete_tags_from_taxonomy(self.taxonomy, ["Bacteria"], with_subtags=True)
 
-        assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id)] == [
+        assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id, include_deleted=True)] == [
             ("bar", False),
             ("foo", False),
             ("tribble", False),
@@ -788,7 +788,7 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
         # Then delete the whole free text taxonomy
         self.free_text_taxonomy.delete()
 
-        assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id)] == [
+        assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id, include_deleted=True)] == [
             ("bar", True),  # <--- Deleted, but the value is preserved
             ("foo", True),  # <--- Deleted, but the value is preserved
             ("tribble", True),  # <--- Deleted, but the value is preserved

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -926,6 +926,9 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
             assert response.data[object_id]["taxonomies"] == []
         else:
             # Make sure the object tags are unchanged:
+            if not self.taxonomy.enabled:  # The taxonomy has to be enabled for us to see the tags though:
+                self.taxonomy.enabled = True
+                self.taxonomy.save()
             assert [ot.value for ot in api.get_object_tags(object_id=object_id)] == ["Fungi"]
 
     @ddt.data(

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1025,6 +1025,14 @@ class TestObjectTagCountsViewSet(TestTagTaxonomyMixin, APITestCase):
                 "course07-unit02-problem02": 2,
             }
 
+    def test_get_counts_invalid_spec(self):
+        """
+        Test handling of an invalid object tag pattern
+        """
+        result = self.client.get(OBJECT_TAG_COUNTS_URL.format(object_id_pattern="abc*def"))
+        assert result.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Wildcard matches are only supported if the * is at the end." in str(result.content)
+
 
 class TestTaxonomyTagsView(TestTaxonomyViewMixin):
     """


### PR DESCRIPTION
This PR:
1. Makes the `get_object_tag_counts` API available via python as well as REST. Previously it was REST-only.
2. Makes the `get_object_tags` and `get_object_tag_counts` APIs ignore tags from deleted or disabled taxonomies by default. Anything else would be confusing for users. Keep in mind, we do preserve the underlying ObjectTag data; we just don't want to display it.

This is for https://github.com/openedx/modular-learning/issues/118 part 1b.

Private ref: [FAL-3564](https://tasks.opencraft.com/browse/FAL-3564).