### PR TITLE
fix: Fix bugs in the "get tags" REST API, make it more consistent [FAL-3530] [FC-0036]

### DIFF
--- a/docs/decisions/0014-single-taxonomy-view-api.rst
+++ b/docs/decisions/0014-single-taxonomy-view-api.rst
@@ -15,7 +15,7 @@ For the decisions, the following use cases were taken into account:
 - As a taxonomy administrator, I want to see all the tags available for use with a closed taxonomy,
   so that I can see the taxonomy's structure in the management interface.
 
-  - As a taxonomy administrator, I want to see the available tags as a lits of root tags
+  - As a taxonomy administrator, I want to see the available tags as a list of root tags
     that can be expanded to show children tags.
   - As a taxonomy administrator, I want to sort the list of root tags alphabetically: A-Z (default) and Z-A.
   - As a taxonomy administrator, I want to expand all root tags to see all children tags.
@@ -23,7 +23,7 @@ For the decisions, the following use cases were taken into account:
 - As a course author, when I am editing the tags of a component, I want to see all the tags available
   from a particular taxonomy that I can use.
 
-  - As a course author, I want to see the available tags as a lits of root tags
+  - As a course author, I want to see the available tags as a list of root tags
     that can be expanded to show children tags.
   - As a course author, I want to search for tags, so I can find root and children tags more easily.
 

--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.3.5"
+__version__ = "0.3.6"

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -493,13 +493,15 @@ class Taxonomy(models.Model):
                     if pk is not None:
                         matching_ids.append(pk)
             qs = qs.filter(pk__in=matching_ids)
+            qs = qs.annotate(child_count=models.Count("children", filter=Q(children__pk__in=matching_ids)))
         elif excluded_values:
             raise NotImplementedError("Using excluded_values without search_term is not currently supported.")
             # We could implement this in the future but I'd prefer to get rid of the "excluded_values" API altogether.
             # It remains to be seen if it's useful to do that on the backend, or if we can do it better/simpler on the
             # frontend.
+        else:
+            qs = qs.annotate(child_count=models.Count("children"))
 
-        qs = qs.annotate(child_count=models.Count("children"))
         # Add the "depth" to each tag:
         qs = Tag.annotate_depth(qs)
         # Add the "lineage" as a field called "sort_key" to sort them in order correctly:

--- a/openedx_tagging/core/tagging/rest_api/paginators.py
+++ b/openedx_tagging/core/tagging/rest_api/paginators.py
@@ -5,10 +5,7 @@ Paginators uses by the REST API
 from edx_rest_framework_extensions.paginators import DefaultPagination  # type: ignore[import]
 
 # From this point, the tags begin to be paginated
-TAGS_THRESHOLD = 1000
-
-# From this point, search tags begin to be paginated
-SEARCH_TAGS_THRESHOLD = 200
+MAX_FULL_DEPTH_THRESHOLD = 10_000
 
 
 class TagsPagination(DefaultPagination):
@@ -29,5 +26,5 @@ class DisabledTagsPagination(DefaultPagination):
     It should be used if the number of tags within
     the taxonomy does not exceed `TAGS_THRESHOLD`.
     """
-    page_size = TAGS_THRESHOLD
-    max_page_size = TAGS_THRESHOLD + 1
+    page_size = MAX_FULL_DEPTH_THRESHOLD
+    max_page_size = MAX_FULL_DEPTH_THRESHOLD + 1

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -691,8 +691,7 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
             # This is because the user did not request a deep response (via full_depth_threshold) or the result was too
             # large (larger than the threshold).
             # It will be paginated normally.
-            min_depth = 0 if parent_tag_value is None else results[0]["depth"]
-            return results.filter(depth=min_depth)
+            return results.filter(parent_value=parent_tag_value)
 
     def post(self, request, *args, **kwargs):
         """

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -660,7 +660,10 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         parent_tag_value = self.request.query_params.get("parent_tag", None)
         include_counts = "include_counts" in self.request.query_params
         search_term = self.request.query_params.get("search_term", None)
-        full_depth_threshold = int(self.request.query_params.get("full_depth_threshold", 0))
+        try:
+            full_depth_threshold = int(self.request.query_params.get("full_depth_threshold", 0))
+        except ValueError:
+            full_depth_threshold = -1
         if full_depth_threshold < 0 or full_depth_threshold > MAX_FULL_DEPTH_THRESHOLD:
             raise ValidationError("Invalid full_depth_threshold")
 

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -539,7 +539,6 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
     **List Query Parameters**
         * id (required) - The ID of the taxonomy to retrieve tags.
         * search_term (optional) - Only return tags matching this term, plus their ancestors. Case insensitive.
-          Note that currently the "children" counts in the result do not reflect the filtering from the search term.
         * parent_tag (optional) - Retrieve children of the tag with this value.
         * full_depth_threshold (optional) - If there are fewer than this many results, return the full (sub)tree of
           results, up to maximum supported depth, in a single giant page of results. By default this is disabled

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -193,11 +193,11 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
     def test_search_tags(self) -> None:
         result = tagging_api.search_tags(self.taxonomy, search_term='eU')
         assert pretty_format_tags(result, parent=False) == [
-            'Archaea (children: 3)',  # Doesn't match 'eU' but is included because a child is included
+            'Archaea (children: 1)',  # Doesn't match 'eU' but is included because a child is included
             '  Euryarchaeida (children: 0)',
-            'Bacteria (children: 2)',  # Doesn't match 'eU' but is included because a child is included
+            'Bacteria (children: 1)',  # Doesn't match 'eU' but is included because a child is included
             '  Eubacteria (children: 0)',
-            'Eukaryota (children: 5)',
+            'Eukaryota (children: 0)',
         ]
 
     @override_settings(LANGUAGES=test_languages)
@@ -603,30 +603,30 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
 
     @ddt.data(
         ("ChA", [
-            "Archaea (used: 1, children: 3)",
+            "Archaea (used: 1, children: 2)",
             "  Euryarchaeida (used: 0, children: 0)",
             "  Proteoarchaeota (used: 0, children: 0)",
-            "Bacteria (used: 0, children: 2)",  # does not contain "cha" but a child does
+            "Bacteria (used: 0, children: 1)",  # does not contain "cha" but a child does
             "  Archaebacteria (used: 1, children: 0)",
         ]),
         ("ar", [
-            "Archaea (used: 1, children: 3)",
+            "Archaea (used: 1, children: 2)",
             "  Euryarchaeida (used: 0, children: 0)",
             "  Proteoarchaeota (used: 0, children: 0)",
-            "Bacteria (used: 0, children: 2)",  # does not contain "ar" but a child does
+            "Bacteria (used: 0, children: 1)",  # does not contain "ar" but a child does
             "  Archaebacteria (used: 1, children: 0)",
-            "Eukaryota (used: 0, children: 5)",
-            "  Animalia (used: 1, children: 7)",  # does not contain "ar" but a child does
+            "Eukaryota (used: 0, children: 1)",
+            "  Animalia (used: 1, children: 2)",  # does not contain "ar" but a child does
             "    Arthropoda (used: 1, children: 0)",
             "    Cnidaria (used: 0, children: 0)",
         ]),
         ("aE", [
-            "Archaea (used: 1, children: 3)",
+            "Archaea (used: 1, children: 2)",
             "  Euryarchaeida (used: 0, children: 0)",
             "  Proteoarchaeota (used: 0, children: 0)",
-            "Bacteria (used: 0, children: 2)",  # does not contain "ae" but a child does
+            "Bacteria (used: 0, children: 1)",  # does not contain "ae" but a child does
             "  Archaebacteria (used: 1, children: 0)",
-            "Eukaryota (used: 0, children: 5)",  # does not contain "ae" but a child does
+            "Eukaryota (used: 0, children: 1)",  # does not contain "ae" but a child does
             "  Plantae (used: 1, children: 0)",
         ]),
         ("a", [
@@ -637,11 +637,11 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
             "Bacteria (used: 0, children: 2)",
             "  Archaebacteria (used: 1, children: 0)",
             "  Eubacteria (used: 0, children: 0)",
-            "Eukaryota (used: 0, children: 5)",
+            "Eukaryota (used: 0, children: 4)",
             "  Animalia (used: 1, children: 7)",
             "    Arthropoda (used: 1, children: 0)",
-            "    Chordata (used: 0, children: 1)",
-            "    Cnidaria (used: 0, children: 0)",
+            "    Chordata (used: 0, children: 0)",  # <<< Chordata has a matching child but we only support searching
+            "    Cnidaria (used: 0, children: 0)",  # 3 levels deep at once for now.
             "    Ctenophora (used: 0, children: 0)",
             "    Gastrotrich (used: 1, children: 0)",
             "    Placozoa (used: 1, children: 0)",
@@ -678,11 +678,11 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
         tagging_api.tag_object(object_id=object_id, taxonomy=self.taxonomy, tags=["Archaebacteria"])
         result = tagging_api.search_tags(self.taxonomy, "ChA", exclude_object_id=object_id)
         assert pretty_format_tags(result, parent=False) == [
-            "Archaea (children: 3)",
+            "Archaea (children: 2)",
             "  Euryarchaeida (children: 0)",
             "  Proteoarchaeota (children: 0)",
             # These results are no longer included because of exclude_object_id:
-            # "Bacteria (children: 2)",  # does not contain "cha" but a child does
+            # "Bacteria (children: 1)",  # does not contain "cha" but a child does
             # "  Archaebacteria (children: 0)",
         ]
 

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -417,10 +417,10 @@ class TestFilteredTagsClosedTaxonomy(TestTagTaxonomyMixin, TestCase):
         """
         result = pretty_format_tags(self.taxonomy.get_filtered_tags(search_term="ARCH"))
         assert result == [
-            "Archaea (None) (children: 3)",  # Matches the value of this root tag, ARCHaea
+            "Archaea (None) (children: 2)",  # Matches the value of this root tag, ARCHaea
             "  Euryarchaeida (Archaea) (children: 0)",  # Matches the value of this child tag
             "  Proteoarchaeota (Archaea) (children: 0)",  # Matches the value of this child tag
-            "Bacteria (None) (children: 2)",  # Does not match this tag but matches a descendant:
+            "Bacteria (None) (children: 1)",  # Does not match this tag but matches a descendant:
             "  Archaebacteria (Bacteria) (children: 0)",  # Matches the value of this child tag
         ]
 
@@ -431,9 +431,25 @@ class TestFilteredTagsClosedTaxonomy(TestTagTaxonomyMixin, TestCase):
         """
         result = pretty_format_tags(self.taxonomy.get_filtered_tags(search_term="chordata"))
         assert result == [
-            "Eukaryota (None) (children: 5)",
-            "  Animalia (Eukaryota) (children: 7)",
-            "    Chordata (Animalia) (children: 1)",  # this is the matching tag.
+            "Eukaryota (None) (children: 1)",  # Has one child that matches
+            "  Animalia (Eukaryota) (children: 1)",
+            "    Chordata (Animalia) (children: 0)",  # this is the matching tag.
+        ]
+
+    def test_search_3(self) -> None:
+        """
+        Another search test, that matches a tag deeper in the taxonomy to check
+        that the correct child_count is returned by the search.
+        """
+        result = pretty_format_tags(self.taxonomy.get_filtered_tags(search_term="RO"))
+        assert result == [
+            "Archaea (None) (children: 1)",
+            "  Proteoarchaeota (Archaea) (children: 0)",
+            "Eukaryota (None) (children: 2)",  # Note the "children: 2" is correct - 2 direct children are in the result
+            "  Animalia (Eukaryota) (children: 2)",
+            "    Arthropoda (Animalia) (children: 0)",  # match
+            "    Gastrotrich (Animalia) (children: 0)",  # match
+            "  Protista (Eukaryota) (children: 0)",  # match
         ]
 
     def test_tags_deep(self) -> None:

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1219,11 +1219,11 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         data = response.data
         assert pretty_format_tags(data["results"], parent=False) == [
-            "Archaea (children: 3)",  # No match in this tag, but a child matches so it's included
+            "Archaea (children: 1)",  # No match in this tag, but a child matches so it's included
             "  Euryarchaeida (children: 0)",
-            "Bacteria (children: 2)",  # No match in this tag, but a child matches so it's included
+            "Bacteria (children: 1)",  # No match in this tag, but a child matches so it's included
             "  Eubacteria (children: 0)",
-            "Eukaryota (children: 5)",
+            "Eukaryota (children: 0)",
         ]
 
         # Checking pagination values
@@ -1245,9 +1245,9 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
 
         data = response.data
         assert pretty_format_tags(data["results"], parent=False) == [
-            "Archaea (children: 3)",  # No match in this tag, but a child matches so it's included
-            "Bacteria (children: 2)",  # No match in this tag, but a child matches so it's included
-            "Eukaryota (children: 5)",
+            "Archaea (children: 1)",  # No match in this tag, but a child matches so it's included
+            "Bacteria (children: 1)",  # No match in this tag, but a child matches so it's included
+            "Eukaryota (children: 0)",
         ]
 
         # Checking pagination values
@@ -1378,10 +1378,12 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         data = response.data
         results = data["results"]
         assert pretty_format_tags(results)[:20] == [
-            "Tag 0 (None) (children: 12)",  # First 2 results don't match but have children that match
-            "  Tag 1 (Tag 0) (children: 12)",
+            "Tag 0 (None) (children: 3)",  # First 2 results don't match but have children that match
+            # Note the count here ---^ is not the total number of matching descendants, just the number of children
+            # once we filter the tree to include only matches and their ancestors.
+            "  Tag 1 (Tag 0) (children: 1)",
             "    Tag 11 (Tag 1) (children: 0)",
-            "  Tag 105 (Tag 0) (children: 12)",  # Non-match but children match
+            "  Tag 105 (Tag 0) (children: 8)",  # Non-match but children match
             "    Tag 110 (Tag 105) (children: 0)",
             "    Tag 111 (Tag 105) (children: 0)",
             "    Tag 112 (Tag 105) (children: 0)",
@@ -1390,9 +1392,9 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
             "    Tag 115 (Tag 105) (children: 0)",
             "    Tag 116 (Tag 105) (children: 0)",
             "    Tag 117 (Tag 105) (children: 0)",
-            "  Tag 118 (Tag 0) (children: 12)",
+            "  Tag 118 (Tag 0) (children: 1)",
             "    Tag 119 (Tag 118) (children: 0)",
-            "Tag 1099 (None) (children: 12)",
+            "Tag 1099 (None) (children: 9)",
             "  Tag 1100 (Tag 1099) (children: 12)",
             "    Tag 1101 (Tag 1100) (children: 0)",
             "    Tag 1102 (Tag 1100) (children: 0)",
@@ -1414,16 +1416,16 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         results2 = data2["results"]
         assert pretty_format_tags(results2) == [
             # Notice that none of these root tags directly match the search query, but their children/grandchildren do
-            "Tag 0 (None) (children: 12)",
-            "Tag 1099 (None) (children: 12)",
-            "Tag 1256 (None) (children: 12)",
-            "Tag 1413 (None) (children: 12)",
-            "Tag 157 (None) (children: 12)",
-            "Tag 1570 (None) (children: 12)",
-            "Tag 1727 (None) (children: 12)",
-            "Tag 1884 (None) (children: 12)",
-            "Tag 2041 (None) (children: 12)",
-            "Tag 2198 (None) (children: 12)",
+            "Tag 0 (None) (children: 3)",
+            "Tag 1099 (None) (children: 9)",
+            "Tag 1256 (None) (children: 2)",
+            "Tag 1413 (None) (children: 1)",
+            "Tag 157 (None) (children: 2)",
+            "Tag 1570 (None) (children: 2)",
+            "Tag 1727 (None) (children: 1)",
+            "Tag 1884 (None) (children: 2)",
+            "Tag 2041 (None) (children: 1)",
+            "Tag 2198 (None) (children: 2)",
         ]
         assert data2.get("count") == 51
         assert data2.get("num_pages") == 6
@@ -1436,9 +1438,9 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
         data3 = response3.data
         # Now the number of results is below our threshold (100), so the subtree gets returned as a single page:
         assert pretty_format_tags(data3["results"]) == [
-            "  Tag 1 (Tag 0) (children: 12)",  # Non-match but children match
+            "  Tag 1 (Tag 0) (children: 1)",  # Non-match but children match
             "    Tag 11 (Tag 1) (children: 0)",  # Matches '11'
-            "  Tag 105 (Tag 0) (children: 12)",  # Non-match but children match
+            "  Tag 105 (Tag 0) (children: 8)",  # Non-match but children match
             "    Tag 110 (Tag 105) (children: 0)",  # Matches '11'
             "    Tag 111 (Tag 105) (children: 0)",
             "    Tag 112 (Tag 105) (children: 0)",
@@ -1447,7 +1449,7 @@ class TestTaxonomyTagsView(TestTaxonomyViewMixin):
             "    Tag 115 (Tag 105) (children: 0)",
             "    Tag 116 (Tag 105) (children: 0)",
             "    Tag 117 (Tag 105) (children: 0)",
-            "  Tag 118 (Tag 0) (children: 12)",
+            "  Tag 118 (Tag 0) (children: 1)",
             "    Tag 119 (Tag 118) (children: 0)",
         ]
 


### PR DESCRIPTION
This change fixes some bugs and inconsistencies in the "get tags" REST API. Hopefully it will be much easier to understand and use now.

Bugs:
* Before, the pagination and tree depth behavior of the function would be different depending on whether a search term was used or not.
* Before, by default, the pagination format and depth of the results would depend on the overall size of the taxonomy, which could produce unexpected results for API consumers who aren't aware of this.
* Before, the pagination would sometimes put a child on a different page than its parent, which was not incorrect but could be confusing.
* When using a search term and loading sub tags using "sub_tags_url", the search term filter would be lost and all children would be returned, even if they didn't match the search.

**New behavior**:
- Only a single layer of results is returned by default, and it's paginated by the page size (which you can customize using `?page_size`).
- Specifying a search term will filter the results as before, but no longer has any impact on the pagination or depth of the results. By default, only a single layer of results is returned. e.g. if you search this taxonomy
   https://github.com/openedx/openedx-learning/blob/2a983c0b43093e802ab2244c75bbf35e4519cc3c/tests/openedx_tagging/core/fixtures/tagging.yaml#L1-L21
   for "Arthropoda", you'll only get "Eukaryota" as the result, because it's the root tag that has a grandchild that matches. You can then recursively follow the `sub_tags_url` on "Eukaryota" and you'll get "Animalia" and then follow `sub_tags_url` again you'll get "Arthropoda". However, there's a more efficient way!
- You can now **opt-in** to a "smart" behavior: using `?full_depth_threshold=1000`, any response that would return fewer than 1,000 tags will return a single giant page of results with all the tags in tree order, up to the maximum supported search depth (3). Unlike before, this now works with any type of query, whether you're searching or not, loading root tags or some deeper tags, or anything else. Also unlike before, this is now based on the number of results that are returned, not the size of the taxonomy.

The `?root_only` parameter has been removed because it's now on by default. If you want the children included in the result (if possible), you just opt-in to that using `?full_depth_threshold`.

There are no changes at all to the python API.

Also, this change seems to work fine with the current implementation of the tagging drawer (i.e. despite the major changes, it's mostly backwards-compatible).