### PR TITLE
fix: overwrite previous tags on import

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -294,7 +294,8 @@ class TaxonomyView(ModelViewSet):
     @action(detail=True, url_path="tags/import", methods=["put"])
     def update_import(self, request: Request, **_kwargs) -> Response:
         """
-        Imports tags from the uploaded file to an already created taxonomy.
+        Imports tags from the uploaded file to an already created taxonomy,
+        overwriting any existing tags.
         """
         body = TaxonomyImportBodySerializer(data=request.data)
         body.is_valid(raise_exception=True)
@@ -304,7 +305,7 @@ class TaxonomyView(ModelViewSet):
 
         taxonomy = self.get_object()
         try:
-            import_success = import_tags(taxonomy, file, parser_format)
+            import_success = import_tags(taxonomy, file, parser_format, replace=True)
 
             if import_success:
                 serializer = self.get_serializer(taxonomy)

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2230,10 +2230,9 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
         response = self.client.get(url)
         tags = response.data["results"]
-        all_tags = [{"value": tag.value} for tag in self.old_tags] + new_tags
-        assert len(tags) == len(all_tags)
+        assert len(tags) == len(new_tags)
         for i, tag in enumerate(tags):
-            assert tag["value"] == all_tags[i]["value"]
+            assert tag["value"] == new_tags[i]["value"]
 
     def test_import_no_file(self) -> None:
         """


### PR DESCRIPTION
## Description
Changes the import endpoint to overwrite previous tags from the target taxonomy

## Supporting Information
* Part of https://github.com/openedx/modular-learning/issues/140

## Testing instructions
* Please ensure that the tests cover the expected behavior of the view
____
Private-ref: [FAL-3536](https://tasks.opencraft.com/browse/FAL-3536)