### PR TITLE
Very minor fixes for import code [FC-0036]

### DIFF
--- a/openedx_tagging/core/tagging/import_export/api.py
+++ b/openedx_tagging/core/tagging/import_export/api.py
@@ -44,19 +44,18 @@ TODO for next versions
 """
 from __future__ import annotations
 
-from io import BytesIO
+from typing import BinaryIO
 
 from django.utils.translation import gettext as _
 
 from ..models import TagImportTask, TagImportTaskState, Taxonomy
-from .exceptions import TagImportError
 from .import_plan import TagImportPlan, TagImportTask
 from .parsers import ParserFormat, get_parser
 
 
 def import_tags(
     taxonomy: Taxonomy,
-    file: BytesIO,
+    file: BinaryIO,
     parser_format: ParserFormat,
     replace=False,
 ) -> bool:
@@ -116,7 +115,7 @@ def import_tags(
         tag_import_plan.execute(task)
         task.end_success()
         return True
-    except (TagImportError, ValueError) as exception:
+    except Exception as exception:  # pylint: disable=broad-exception-caught
         # Log any exception
         task.log_exception(exception)
         return False

--- a/openedx_tagging/core/tagging/import_export/parsers.py
+++ b/openedx_tagging/core/tagging/import_export/parsers.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import csv
 import json
 from enum import Enum
-from io import BytesIO, StringIO, TextIOWrapper
+from io import StringIO, TextIOWrapper
+from typing import BinaryIO
 
 from django.utils.translation import gettext as _
 
@@ -51,7 +52,7 @@ class Parser:
     inital_row = 1
 
     @classmethod
-    def parse_import(cls, file: BytesIO) -> tuple[list[TagItem], list[TagParserError]]:
+    def parse_import(cls, file: BinaryIO) -> tuple[list[TagItem], list[TagParserError]]:
         """
         Parse tags in file an returns tags ready for use in TagImportPlan
 
@@ -79,7 +80,7 @@ class Parser:
         return cls._export_data(tags, taxonomy)
 
     @classmethod
-    def _load_data(cls, file: BytesIO) -> tuple[list[dict], list[TagParserError]]:
+    def _load_data(cls, file: BinaryIO) -> tuple[list[dict], list[TagParserError]]:
         """
         Each parser implements this function according to its format.
         This function reads the file and returns a list with the values of each tag.
@@ -206,7 +207,7 @@ class JSONParser(Parser):
     inital_row = 0
 
     @classmethod
-    def _load_data(cls, file: BytesIO) -> tuple[list[dict], list[TagParserError]]:
+    def _load_data(cls, file: BinaryIO) -> tuple[list[dict], list[TagParserError]]:
         """
         Read a .json file and validates the root structure of the json
         """
@@ -259,7 +260,7 @@ class CSVParser(Parser):
     inital_row = 2
 
     @classmethod
-    def _load_data(cls, file: BytesIO) -> tuple[list[dict], list[TagParserError]]:
+    def _load_data(cls, file: BinaryIO) -> tuple[list[dict], list[TagParserError]]:
         """
         Read a .csv file and validates the header fields
         """


### PR DESCRIPTION
* The import code that accepts a file object should have type `BinaryIO` (any file-like object that produces bytes), not `BytesIO` (specifically an in-memory bytes object and not a file handle)
* As I experienced, if a `TypeError` occurred during import (e.g. because you forgot to open the CSV file as binary instead of as a string...) then the import task would become permanently stuck because `TypeError` exceptions were not caught.

No need for a version bump with this fix.

Private ref: can be considered part of FAL-3531.