### PR TITLE
 fix: skip parent update from deleted tags 

### DIFF
--- a/openedx_tagging/core/tagging/import_export/actions.py
+++ b/openedx_tagging/core/tagging/import_export/actions.py
@@ -373,8 +373,7 @@ class DeleteTag(ImportAction):
     """
 
     def __str__(self) -> str:
-        taxonomy_tag = self._get_tag()
-        return str(_("Delete tag (external_id={external_id})").format(external_id=taxonomy_tag.external_id))
+        return str(_("Delete tag (external_id={external_id})").format(external_id=self.tag.id))
 
     name = "delete"
 
@@ -397,8 +396,11 @@ class DeleteTag(ImportAction):
         """
         Delete a tag
         """
-        taxonomy_tag = self._get_tag()
-        taxonomy_tag.delete()
+        try:
+            taxonomy_tag = self._get_tag()
+            taxonomy_tag.delete()
+        except Tag.DoesNotExist:
+            pass  # The tag may be already cascade deleted if the parent tag was deleted
 
 
 class WithoutChanges(ImportAction):

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -93,14 +93,16 @@ class TagImportPlan:
                 # Verify if there is not a parent update before
                 if not self._search_parent_update(child.external_id, tag.external_id):
                     # Change parent to avoid delete childs
-                    self._build_action(
-                        UpdateParentTag,
-                        TagItem(
-                            id=child.external_id,
-                            value=child.value,
-                            parent_id=None,
-                        ),
-                    )
+                    if child.external_id not in tags:
+                        # Only update parent if the child is not going to be deleted
+                        self._build_action(
+                            UpdateParentTag,
+                            TagItem(
+                                id=child.external_id,
+                                value=child.value,
+                                parent_id=None,
+                            ),
+                        )
 
             # Delete action
             self._build_action(

--- a/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
@@ -60,23 +60,15 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
         assert len(self.import_plan.errors) == 0
 
         # Check actions in order
-        # #1 Update parent of 'tag_2'
-        assert self.import_plan.actions[0].name == 'update_parent'
-        assert self.import_plan.actions[0].tag.id == 'tag_2'
-        assert self.import_plan.actions[0].tag.parent_id is None
-        # #2 Delete 'tag_1'
+        # #1 Delete 'tag_1'
+        assert self.import_plan.actions[0].name == 'delete'
+        assert self.import_plan.actions[0].tag.id == 'tag_1'
+        # #2 Delete 'tag_2'
         assert self.import_plan.actions[1].name == 'delete'
-        assert self.import_plan.actions[1].tag.id == 'tag_1'
-        # #3 Delete 'tag_2'
+        assert self.import_plan.actions[1].tag.id == 'tag_2'
+        # #3 Delete 'tag_3'
         assert self.import_plan.actions[2].name == 'delete'
-        assert self.import_plan.actions[2].tag.id == 'tag_2'
-        # #4 Update parent of 'tag_4'
-        assert self.import_plan.actions[3].name == 'update_parent'
-        assert self.import_plan.actions[3].tag.id == 'tag_4'
-        assert self.import_plan.actions[3].tag.parent_id is None
-        # #5 Delete 'tag_3'
-        assert self.import_plan.actions[4].name == 'delete'
-        assert self.import_plan.actions[4].tag.id == 'tag_3'
+        assert self.import_plan.actions[2].tag.id == 'tag_3'
 
     @ddt.data(
         # Test valid actions
@@ -192,10 +184,6 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
                 {
                     'name': 'without_changes',
                     'id': 'tag_4',
-                },
-                {
-                    'name': 'update_parent',
-                    'id': 'tag_2',
                 },
                 {
                     'name': 'delete',
@@ -330,13 +318,11 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             "Import plan for Import Taxonomy Test\n"
             "--------------------------------\n"
             "#1: No changes needed for tag (external_id=tag_4)\n"
-            "#2: Update the parent of tag (external_id=tag_2) from parent (external_id=tag_1) "
+            "#2: Delete tag (external_id=tag_1)\n"
+            "#3: Delete tag (external_id=tag_2)\n"
+            "#4: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
             "to parent (external_id=None).\n"
-            "#3: Delete tag (external_id=tag_1)\n"
-            "#4: Delete tag (external_id=tag_2)\n"
-            "#5: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
-            "to parent (external_id=None).\n"
-            "#6: Delete tag (external_id=tag_3)\n"
+            "#5: Delete tag (external_id=tag_3)\n"
         ),
     )
     @ddt.unpack


### PR DESCRIPTION
## Description
This PR prevents creating an `UpdateParent` action associated with a Tag that will be deleted.

Example:
```
- Tag 1
  - Tag 1.1
    - Tag 1.1.1
```

Actions before PR:
```
#1 Delete Tag 1
#2 Delete Tag 1.1
#3 Delete Tag 1.1.1
#4 Update parent tag of Tag 1.1 from Tag 1 to None (** THIS FAILS BECAUSE Tag 1.1 WAS DELETED **)
#5 Update parent tag of Tag 1.1.1 from Tag 1.1 to None  (** THIS FAILS BECAUSE Tag 1.1.1 WAS DELETED **)
```

Actions after PR:
```
#1 Delete Tag 1
#2 Delete Tag 1.1
#3 Delete Tag 1.1.1
```

It also checks if the Tag actually exists in the database before executing the `Delete` action. In the example above, because we didn't update the parent of tags 1.1 and 1.1.1, actions `#2` and `#3` should be skipped because both tags were cascade deleted on action `#1`.

## Testing instructions
* Please ensure that the tests cover the expected behavior and that the new test that reproduces the bug passes

____
Private-ref:
 - [FAL-3568](https://tasks.opencraft.com/browse/FAL-3568)