### PR TITLE
feat: add plan_only param to api and create /tags/import/plan endpoint [FC-0036]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/openedx_tagging/core/tagging/import_export/tasks.py
+++ b/openedx_tagging/core/tagging/import_export/tasks.py
@@ -1,6 +1,8 @@
 """
 Import and export celery tasks
 """
+from __future__ import annotations
+
 from io import BytesIO
 
 from celery import shared_task  # type: ignore[import]
@@ -8,6 +10,7 @@ from celery import shared_task  # type: ignore[import]
 import openedx_tagging.core.tagging.import_export.api as import_export_api
 
 from ..models import Taxonomy
+from .import_plan import TagImportPlan, TagImportTask
 from .parsers import ParserFormat
 
 
@@ -17,7 +20,7 @@ def import_tags_task(
     file: BytesIO,
     parser_format: ParserFormat,
     replace=False,
-) -> bool:
+) -> tuple[bool, TagImportTask, TagImportPlan | None]:
     """
     Runs import on a celery task
     """

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -11,7 +11,7 @@ from rest_framework.reverse import reverse
 
 from openedx_tagging.core.tagging.data import TagData
 from openedx_tagging.core.tagging.import_export.parsers import ParserFormat
-from openedx_tagging.core.tagging.models import ObjectTag, Tag, Taxonomy
+from openedx_tagging.core.tagging.models import ObjectTag, Tag, TagImportTask, Taxonomy
 
 
 class TaxonomyListQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -257,3 +257,42 @@ class TaxonomyImportNewBodySerializer(TaxonomyImportBodySerializer):  # pylint: 
     """
     taxonomy_name = serializers.CharField(required=True)
     taxonomy_description = serializers.CharField(default="")
+
+
+class TagImportTaskSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the TagImportTask model.
+    """
+    class Meta:
+        model = TagImportTask
+        fields = [
+            "id",
+            "log",
+            "status",
+            "creation_date",
+        ]
+
+
+class TaxonomyImportPlanResponseSerializer(serializers.Serializer):
+    """
+    Serializer for the response of the Taxonomy Import Plan request
+    """
+    task = TagImportTaskSerializer()
+    plan = serializers.SerializerMethodField()
+    error = serializers.CharField(required=False, allow_null=True)
+
+    def get_plan(self, obj):
+        """
+        Returns the plan of the import
+        """
+        plan = obj.get("plan", None)
+        if plan:
+            return plan.plan()
+
+        return None
+
+    def update(self, instance, validated_data):
+        raise RuntimeError('`update()` is not supported by the TagImportTask serializer.')
+
+    def create(self, validated_data):
+        raise RuntimeError('`create()` is not supported by the TagImportTask serializer.')

--- a/tests/openedx_tagging/core/tagging/import_export/test_tasks.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_tasks.py
@@ -23,9 +23,11 @@ class TestImportExportCeleryTasks(TestImportExportMixin, TestCase):
         replace = True
 
         with patch('openedx_tagging.core.tagging.import_export.api.import_tags') as mock_import_tags:
-            mock_import_tags.return_value = True
+            mock_import_tags.return_value = (True, None, None)
 
-            result = import_export_tasks.import_tags_task(self.taxonomy, file, parser_format, replace)
+            result, _result_task, _result_plan = import_export_tasks.import_tags_task(
+                self.taxonomy, file, parser_format, replace
+            )
 
             self.assertTrue(result)
             mock_import_tags.assert_called_once_with(self.taxonomy, file, parser_format, replace)

--- a/tests/openedx_tagging/core/tagging/import_export/test_template.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_template.py
@@ -41,12 +41,13 @@ class TestImportTemplate(TestImportExportMixin, TestCase):
     @ddt.unpack
     def test_import_template(self, template_file, parser_format):
         with self.open_template_file(template_file) as import_file:
-            assert import_api.import_tags(
+            result, _task, _plan = import_api.import_tags(
                 self.taxonomy,
                 import_file,
                 parser_format,
                 replace=True,
-            ), import_api.get_last_import_log(self.taxonomy)
+            )
+            assert result, import_api.get_last_import_log(self.taxonomy)
 
         assert pretty_format_tags(get_tags(self.taxonomy), external_id=True) == [
             'Electronic instruments (ELECTRIC) (None) (children: 2)',

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2457,7 +2457,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
 
     def test_import_plan_no_file(self) -> None:
         """
-        Tests planning impprt a taxonomy without a file.
+        Tests planning import a taxonomy without a file.
         """
         url = TAXONOMY_TAGS_IMPORT_PLAN_URL.format(pk=self.taxonomy.id)
         self.client.force_authenticate(user=self.staff)

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2689,4 +2689,3 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
         self._check_taxonomy_not_changed()
-

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2435,6 +2435,17 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
             format="multipart"
         )
         assert response.status_code == status.HTTP_200_OK
+        assert response.data["error"] is None
+        assert response.data["task"]["status"] == "success"
+        expected_plan = "Import plan for Test import taxonomy\n" \
+            + "--------------------------------\n" \
+            + "#1: Create a new tag with values (external_id=tag_1, value=Tag 1, parent_id=None).\n" \
+            + "#2: Create a new tag with values (external_id=tag_2, value=Tag 2, parent_id=None).\n" \
+            + "#3: Create a new tag with values (external_id=tag_3, value=Tag 3, parent_id=None).\n" \
+            + "#4: Create a new tag with values (external_id=tag_4, value=Tag 4, parent_id=None).\n" \
+            + "#5: Delete tag (external_id=old_tag_1)\n" \
+            + "#6: Delete tag (external_id=old_tag_2)\n"
+        assert response.data["plan"] == expected_plan
 
         self._check_taxonomy_not_changed()
 

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2349,6 +2349,17 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
     """
     Tests the taxonomy import tags action.
     """
+    def _check_taxonomy_not_changed(self) -> None:
+        """
+        Checks if the self.taxonomy have the original tags.
+        """
+        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
+        response = self.client.get(url)
+        tags = response.data["results"]
+        assert len(tags) == len(self.old_tags)
+        for i, tag in enumerate(tags):
+            assert tag["value"] == self.old_tags[i].value
+
     def setUp(self):
         ImportTaxonomyMixin.setUp(self)
 
@@ -2425,13 +2436,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         )
         assert response.status_code == status.HTTP_200_OK
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     def test_import_no_file(self) -> None:
         """
@@ -2447,13 +2452,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data["file"][0] == "No file was submitted."
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     def test_import_plan_no_file(self) -> None:
         """
@@ -2469,13 +2468,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data["file"][0] == "No file was submitted."
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     def test_import_invalid_format(self) -> None:
         """
@@ -2492,13 +2485,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data["file"][0] == "File type not supported: invalid"
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     def test_import_plan_invalid_format(self) -> None:
         """
@@ -2515,13 +2502,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data["file"][0] == "File type not supported: invalid"
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     @ddt.data(
         "csv",
@@ -2546,13 +2527,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert f"Invalid '.{file_format}' format:" in response.data
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     @ddt.data(
         "csv",
@@ -2577,13 +2552,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert f"Invalid '.{file_format}' format:" in response.data["error"]
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     @ddt.data(
         "csv",
@@ -2681,13 +2650,7 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
 
     def test_import_plan_no_perm(self) -> None:
         """
@@ -2714,10 +2677,5 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-        # Check if the taxonomy was not changed
-        url = TAXONOMY_TAGS_URL.format(pk=self.taxonomy.id)
-        response = self.client.get(url)
-        tags = response.data["results"]
-        assert len(tags) == len(self.old_tags)
-        for i, tag in enumerate(tags):
-            assert tag["value"] == self.old_tags[i].value
+        self._check_taxonomy_not_changed()
+


### PR DESCRIPTION
## Description
This PR adds a `plan_only` param to the API and creates a new REST endpoint to allow the frontend to query for an import plan without actually importing anything.

## More info
Part of:
 - https://github.com/openedx/modular-learning/issues/126

## Testing instructions
* Please ensure that the tests cover the expected behavior
____
Private-ref:
 - [FAL-3539](https://tasks.opencraft.com/browse/FAL-3539)