### PR TITLE
feat: Count implicit tags

### DIFF
--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -21,7 +21,7 @@ from django.utils.translation import gettext as _
 
 from .data import TagDataQuerySet
 from .models import ObjectTag, Tag, Taxonomy
-from .models.utils import ConcatNull
+from .models.utils import ConcatNull, StringAgg
 
 # Export this as part of the API
 TagDoesNotExist = Tag.DoesNotExist
@@ -218,13 +218,32 @@ def get_object_tag_counts(object_id_pattern: str, count_implicit=False) -> dict[
     qs = qs.exclude(taxonomy__enabled=False)  # The whole taxonomy is disabled
     qs = qs.exclude(tag_id=None, taxonomy__allow_free_text=False)  # The taxonomy exists but the tag is deleted
     if count_implicit:
-        tags = Tag.annotate_depth(Tag.objects.filter(pk=models.OuterRef("tag_id")))
-        qs = qs.annotate(tag_depth=models.Subquery(tags.values('depth')))
+        # Counting the implicit tags is tricky, because if two "grandchild" tags have the same implicit parent tag, we
+        # need to count that parent tag only once. To do that, we collect all the ancestor tag IDs into an aggregate
+        # string, and then count the unique values using python
         qs = qs.values("object_id").annotate(
             num_tags=models.Count("id"),
-            num_implicit_tags=models.Sum("tag_depth"),
+            tag_ids_str_1=StringAgg("tag_id"),
+            tag_ids_str_2=StringAgg("tag__parent_id"),
+            tag_ids_str_3=StringAgg("tag__parent__parent_id"),
+            tag_ids_str_4=StringAgg("tag__parent__parent__parent_id"),
         ).order_by("object_id")
-        return {row["object_id"]: row["num_tags"] + (row["num_implicit_tags"] or 0) for row in qs}
+        result = {}
+        for row in qs:
+            # ObjectTags for free text taxonomies will be included in "num_tags" count, but not "tag_ids_str_1" since
+            # they have no tag ID. We can compute how many free text tags each object has now:
+            if row["tag_ids_str_1"]:
+                num_free_text_tags = row["num_tags"] - len(row["tag_ids_str_1"].split(","))
+            else:
+                num_free_text_tags = row["num_tags"]
+            # Then we count the total number of *unique* Tags for this object, both implicit and explicit:
+            other_tag_ids = set()
+            for field in ("tag_ids_str_1", "tag_ids_str_2", "tag_ids_str_3", "tag_ids_str_4"):
+                if row[field] is not None:
+                    for tag_id in row[field].split(","):
+                        other_tag_ids.add(int(tag_id))
+            result[row["object_id"]] = num_free_text_tags + len(other_tag_ids)
+        return result
     else:
         qs = qs.values("object_id").annotate(num_tags=models.Count("id")).order_by("object_id")
         return {row["object_id"]: row["num_tags"] for row in qs}

--- a/openedx_tagging/core/tagging/models/utils.py
+++ b/openedx_tagging/core/tagging/models/utils.py
@@ -1,7 +1,7 @@
 """
 Utilities for tagging and taxonomy models
 """
-
+from django.db.models import Aggregate, CharField
 from django.db.models.expressions import Func
 
 
@@ -21,4 +21,24 @@ class ConcatNull(Func):  # pylint: disable=abstract-method
             template="%(expressions)s",
             arg_joiner=" || ",
             **extra_context,
+        )
+
+
+class StringAgg(Aggregate):  # pylint: disable=abstract-method
+    """
+    Aggregate function that collects the values of some column across all rows,
+    and creates a string by concatenating those values, with "," as a separator.
+
+    This is the same as Django's django.contrib.postgres.aggregates.StringAgg,
+    but this version works with MySQL and SQLite.
+    """
+    function = 'GROUP_CONCAT'
+    template = '%(function)s(%(distinct)s%(expressions)s)'
+
+    def __init__(self, expression, distinct=False, **extra):
+        super().__init__(
+            expression,
+            distinct='DISTINCT ' if distinct else '',
+            output_field=CharField(),
+            **extra,
         )

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -496,9 +496,11 @@ class ObjectTagCountsView(
     **Retrieve Parameters**
         * object_id_pattern (required): - The Object ID to retrieve ObjectTags for. Can contain '*' at the end
           for wildcard matching, or use ',' to separate multiple object IDs.
+        * count_implicit (optional): If present, implicit parent/grandparent tags will be included in the counts
 
     **Retrieve Example Requests**
         GET api/tagging/v1/object_tag_counts/:object_id_pattern
+        GET api/tagging/v1/object_tag_counts/:object_id_pattern?count_implicit
 
     **Retrieve Query Returns**
         * 200 - Success
@@ -517,8 +519,9 @@ class ObjectTagCountsView(
         """
         # This API does NOT bother doing any permission checks as the # of tags is not considered sensitive information.
         object_id_pattern = self.kwargs["object_id_pattern"]
+        count_implicit = "count_implicit" in request.query_params
         try:
-            return Response(get_object_tag_counts(object_id_pattern))
+            return Response(get_object_tag_counts(object_id_pattern, count_implicit=count_implicit))
         except ValueError as err:
             raise ValidationError(err.args[0]) from err
 

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1028,10 +1028,14 @@ class TestObjectTagCountsViewSet(TestTagTaxonomyMixin, APITestCase):
         # Course 7 Unit 2
         api.tag_object(object_id="course07-unit02-problem01", taxonomy=self.free_text_taxonomy, tags=["b"])
         api.tag_object(object_id="course07-unit02-problem02", taxonomy=self.free_text_taxonomy, tags=["c", "d"])
-        api.tag_object(object_id="course07-unit02-problem03", taxonomy=self.free_text_taxonomy, tags=["N", "M", "x"])
+        api.tag_object(object_id="course07-unit02-problem03", taxonomy=self.free_text_taxonomy, tags=["N", "M"])
+        api.tag_object(object_id="course07-unit02-problem03", taxonomy=self.taxonomy, tags=["Mammalia"])
 
-        def check(object_id_pattern: str):
-            result = self.client.get(OBJECT_TAG_COUNTS_URL.format(object_id_pattern=object_id_pattern))
+        def check(object_id_pattern: str, count_implicit=False):
+            url = OBJECT_TAG_COUNTS_URL.format(object_id_pattern=object_id_pattern)
+            if count_implicit:
+                url += "?count_implicit"
+            result = self.client.get(url)
             assert result.status_code == status.HTTP_200_OK
             return result.data
 
@@ -1043,6 +1047,20 @@ class TestObjectTagCountsViewSet(TestTagTaxonomyMixin, APITestCase):
             assert check(object_id_pattern="course07-unit01-*") == {
                 "course07-unit01-problem01": 3,
                 "course07-unit01-problem02": 2,
+            }
+        with self.assertNumQueries(1):
+            assert check(object_id_pattern="course07-unit02-*") == {
+                "course07-unit02-problem01": 1,
+                "course07-unit02-problem02": 2,
+                "course07-unit02-problem03": 3,
+            }
+        with self.assertNumQueries(1):
+            assert check(object_id_pattern="course07-unit02-*", count_implicit=True) == {
+                "course07-unit02-problem01": 1,
+                "course07-unit02-problem02": 2,
+                # "Mammalia" includes 1 explicit + 3 implicit tags: "Eukaryota > Animalia > Chordata > Mammalia"
+                # so problem03 has 2 free text tags and "4" life on earth tags:
+                "course07-unit02-problem03": 6,
             }
         with self.assertNumQueries(1):
             assert check(object_id_pattern="course07-unit*") == {


### PR DESCRIPTION
This updates our "get tag counts" API so that the tag counts can include the implicit tags.

Currently, we have an inconsistency in how the counts are displayed in the platform:
![Screenshot 2023-12-14 at 10 19 56 AM](https://github.com/openedx/openedx-learning/assets/945577/d5b82975-ec3f-4fe6-95bf-df973dadc065)
![Screenshot 2023-12-14 at 10 21 07 AM](https://github.com/openedx/openedx-learning/assets/945577/a8a54610-3998-49c5-ad37-6ed2aff77ecf)

This API change will allow us to make the counts in both places include the implicit tags (use the higher number consistently).


Private ref: FAL-3573