### PR TITLE
fix: Issue when delete all tags on import [FC-0036]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/openedx_tagging/core/tagging/import_export/actions.py
+++ b/openedx_tagging/core/tagging/import_export/actions.py
@@ -259,6 +259,16 @@ class UpdateParentTag(ImportAction):
     def __str__(self) -> str:
         taxonomy_tag = self._get_tag()
 
+        if taxonomy_tag.external_id:
+            prefix_str = _("Update the parent of tag (external_id={external_id})").format(
+                external_id=taxonomy_tag.external_id
+            )
+        else:
+            prefix_str = ""
+            prefix_str = _("Update the parent of tag (value={value})").format(
+                value=taxonomy_tag.value
+            )
+
         if not taxonomy_tag.parent:
             from_str = _("from empty parent")
         else:
@@ -270,17 +280,6 @@ class UpdateParentTag(ImportAction):
                 from_str = _("from parent (value={value})").format(
                     value=taxonomy_tag.parent.value
                 )
-                from_str = ""
-
-        if taxonomy_tag.external_id:
-            prefix_str = _("Update the parent of tag (external_id={external_id})").format(
-                external_id=taxonomy_tag.external_id
-            )
-        else:
-            prefix_str = ""
-            prefix_str = _("Update the parent of tag (value={value})").format(
-                value=taxonomy_tag.value
-            )
 
         return str(
             _(

--- a/openedx_tagging/core/tagging/import_export/actions.py
+++ b/openedx_tagging/core/tagging/import_export/actions.py
@@ -72,7 +72,9 @@ class ImportAction:
         """
         Returns the respective tag of this actions
         """
-        return self.taxonomy.tag_set.get(external_id=self.tag.id)
+        if self.tag.id:
+            return self.taxonomy.tag_set.get(external_id=self.tag.id)
+        return self.taxonomy.tag_set.get(value=self.tag.value)
 
     def _search_action(
         self,
@@ -256,16 +258,35 @@ class UpdateParentTag(ImportAction):
 
     def __str__(self) -> str:
         taxonomy_tag = self._get_tag()
+
         if not taxonomy_tag.parent:
             from_str = _("from empty parent")
         else:
-            from_str = _("from parent (external_id={external_id})").format(external_id=taxonomy_tag.parent.external_id)
+            if taxonomy_tag.parent.external_id:
+                from_str = _("from parent (external_id={external_id})").format(
+                    external_id=taxonomy_tag.parent.external_id
+                )
+            else:
+                from_str = _("from parent (value={value})").format(
+                    value=taxonomy_tag.parent.value
+                )
+                from_str = ""
+
+        if taxonomy_tag.external_id:
+            prefix_str = _("Update the parent of tag (external_id={external_id})").format(
+                external_id=taxonomy_tag.external_id
+            )
+        else:
+            prefix_str = ""
+            prefix_str = _("Update the parent of tag (value={value})").format(
+                value=taxonomy_tag.value
+            )
 
         return str(
             _(
-                "Update the parent of tag (external_id={external_id}) "
+                "{prefix_str} "
                 "{from_str} to parent (external_id={parent_id})."
-            ).format(external_id=taxonomy_tag.external_id, from_str=from_str, parent_id=self.tag.parent_id)
+            ).format(prefix_str=prefix_str, from_str=from_str, parent_id=self.tag.parent_id)
         )
 
     @classmethod
@@ -323,11 +344,18 @@ class RenameTag(ImportAction):
 
     def __str__(self) -> str:
         taxonomy_tag = self._get_tag()
+        if taxonomy_tag.external_id:
+            prefix_str = _("Rename tag value of tag (external_id={external_id})").format(
+                external_id=taxonomy_tag.external_id
+            )
+        else:
+            prefix_str = _("Rename tag value of tag (id={id})").format(id=taxonomy_tag.id)
+
         return str(
             _(
-                "Rename tag value of tag (external_id={external_id}) "
+                "{prefix_str} "
                 "from '{from_value}' to '{to_value}'"
-            ).format(external_id=taxonomy_tag.external_id, from_value=taxonomy_tag.value, to_value=self.tag.value)
+            ).format(prefix_str=prefix_str, from_value=taxonomy_tag.value, to_value=self.tag.value)
         )
 
     @classmethod
@@ -373,7 +401,9 @@ class DeleteTag(ImportAction):
     """
 
     def __str__(self) -> str:
-        return str(_("Delete tag (external_id={external_id})").format(external_id=self.tag.id))
+        if self.tag.id:
+            return str(_("Delete tag (external_id={external_id})").format(external_id=self.tag.id))
+        return str(_("Delete tag (value={value})").format(value=self.tag.value))
 
     name = "delete"
 
@@ -413,7 +443,9 @@ class WithoutChanges(ImportAction):
     name = "without_changes"
 
     def __str__(self) -> str:
-        return str(_("No changes needed for tag (external_id={external_id})").format(external_id=self.tag.id))
+        if self.tag.id:
+            return str(_("No changes needed for tag (external_id={external_id})").format(external_id=self.tag.id))
+        return str(_("No changes needed for tag (value={value})").format(value=self.tag.value))
 
     @classmethod
     def applies_for(cls, taxonomy: Taxonomy, tag) -> bool:

--- a/openedx_tagging/core/tagging/import_export/actions.py
+++ b/openedx_tagging/core/tagging/import_export/actions.py
@@ -273,8 +273,8 @@ class UpdateParentTag(ImportAction):
         taxonomy_tag = self._get_tag()
 
         description_str = _("Update the parent of {tag} from parent {old_parent} to {new_parent}").format(
-            tag=taxonomy_tag,
-            old_parent=taxonomy_tag.parent,
+            tag=taxonomy_tag.display_str(),
+            old_parent=taxonomy_tag.parent.display_str() if taxonomy_tag.parent else None,
             new_parent=self.tag.parent_id,
         )
 
@@ -336,7 +336,7 @@ class RenameTag(ImportAction):
     def __str__(self) -> str:
         taxonomy_tag = self._get_tag()
         description_str = _("Rename tag value of {tag} to '{new_value}'").format(
-            tag=taxonomy_tag,
+            tag=taxonomy_tag.display_str(),
             new_value=self.tag.value,
         )
 
@@ -385,9 +385,7 @@ class DeleteTag(ImportAction):
     """
 
     def __str__(self) -> str:
-        if self.tag.id:
-            return str(_("Delete tag (external_id={external_id})").format(external_id=self.tag.id))
-        return str(_("Delete tag (value={value})").format(value=self.tag.value))
+        return str(_("Delete tag {tag}").format(tag=self.tag))
 
     name = "delete"
 

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -136,7 +136,7 @@ class TagImportPlan:
 
         if replace:
             tags_for_delete = {
-                tag.external_id: tag for tag in self.taxonomy.tag_set.all()
+                tag.external_id or tag.id: tag for tag in self.taxonomy.tag_set.all()
             }
 
         for tag in tags:

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -22,6 +22,14 @@ class TagItem:
     index: int | None = 0
     parent_id: str | None = None
 
+    def __str__(self):
+        """
+        User-facing string representation of a Tag.
+        """
+        if self.id:
+            return f"<{self.__class__.__name__}> ({self.id} / {self.value})"
+        return f"<{self.__class__.__name__}> ({self.value})"
+
 
 class TagImportPlan:
     """

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from attrs import define
 from django.db import transaction
 
-from ..models import TagImportTask, Taxonomy
+from ..models import Tag, TagImportTask, Taxonomy
 from .actions import DeleteTag, ImportAction, UpdateParentTag, WithoutChanges, available_actions
 from .exceptions import ImportActionError
 
@@ -84,6 +84,18 @@ class TagImportPlan:
 
         return False
 
+    def _get_tag_id(self, tag: Tag) -> str:
+        """
+        Get the id used on the Tag model.
+
+        By default, the external_id is used for import and export,
+        but there are cases where taxonomies are created without external_id.
+        In those cases the tag id is used
+        """
+        if tag.external_id:
+            return tag.external_id
+        return str(tag.id)
+
     def _build_delete_actions(self, tags: dict):
         """
         Adds delete actions for `tags`
@@ -91,9 +103,9 @@ class TagImportPlan:
         for tag in tags.values():
             for child in tag.children.all():
                 # Verify if there is not a parent update before
-                if not self._search_parent_update(child.external_id, tag.external_id):
+                if not self._search_parent_update(self._get_tag_id(child), self._get_tag_id(tag)):
                     # Change parent to avoid delete childs
-                    if child.external_id not in tags:
+                    if self._get_tag_id(child) not in tags:
                         # Only update parent if the child is not going to be deleted
                         self._build_action(
                             UpdateParentTag,
@@ -136,7 +148,7 @@ class TagImportPlan:
 
         if replace:
             tags_for_delete = {
-                tag.external_id or tag.id: tag for tag in self.taxonomy.tag_set.all()
+                self._get_tag_id(tag): tag for tag in self.taxonomy.tag_set.all()
             }
 
         for tag in tags:

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -94,7 +94,9 @@ class Tag(models.Model):
         """
         User-facing string representation of a Tag.
         """
-        return f"<{self.__class__.__name__}> ({self.id}) {self.value}"
+        if self.external_id:
+            return f"<{self.__class__.__name__}> ({self.id} / {self.external_id} / {self.value})"
+        return f"<{self.__class__.__name__}> ({self.id} / {self.value})"
 
     def get_lineage(self) -> Lineage:
         """

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -94,9 +94,15 @@ class Tag(models.Model):
         """
         User-facing string representation of a Tag.
         """
+        return f"<{self.__class__.__name__}> ({self.id}) {self.value}"
+
+    def display_str(self):
+        """
+        String representation of a Tag used on user logs.
+        """
         if self.external_id:
-            return f"<{self.__class__.__name__}> ({self.id} / {self.external_id} / {self.value})"
-        return f"<{self.__class__.__name__}> ({self.id} / {self.value})"
+            return f"<{self.__class__.__name__}> ({self.external_id} / {self.value})"
+        return f"<{self.__class__.__name__}> ({self.value})"
 
     def get_lineage(self) -> Lineage:
         """

--- a/tests/openedx_tagging/core/tagging/import_export/test_actions.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_actions.py
@@ -310,6 +310,34 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
         )
         assert str(action) == expected
 
+    def test_str_no_external_id(self):
+        tag_1 = Tag(
+            value="Tag 5",
+            taxonomy=self.taxonomy,
+        )
+        tag_1.save()
+        tag_2 = Tag(
+            value="Tag 6",
+            taxonomy=self.taxonomy,
+            parent=tag_1,
+        )
+        tag_2.save()
+        tag_item = TagItem(
+            id=None,
+            value='Tag 6',
+            parent_id='tag_3',
+        )
+        action = UpdateParentTag(
+            taxonomy=self.taxonomy,
+            tag=tag_item,
+            index=100,
+        )
+        expected = (
+            "Update the parent of tag (value=Tag 6) from parent (value=Tag 5)"
+            " to parent (external_id=tag_3)."
+        )
+        assert str(action) == expected
+
     @ddt.data(
         ('tag_100', None, False),  # Tag doesn't exist on database
         ('tag_2', 'tag_1', False),  # Parent don't change

--- a/tests/openedx_tagging/core/tagging/import_export/test_actions.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_actions.py
@@ -283,16 +283,16 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
             "tag_4",
             "tag_3",
             (
-                "Update the parent of tag (external_id=tag_4) from parent "
-                "(external_id=tag_3) to parent (external_id=tag_3)."
+                "Update the parent of <Tag> (29 / tag_4 / Tag 4) "
+                "from parent <Tag> (28 / tag_3 / Tag 3) to tag_3"
             )
         ),
         (
             "tag_3",
             "tag_2",
             (
-                "Update the parent of tag (external_id=tag_3) from empty parent "
-                "to parent (external_id=tag_2)."
+                "Update the parent of <Tag> (28 / tag_3 / Tag 3) "
+                "from parent None to tag_2"
             )
         ),
     )
@@ -333,8 +333,8 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
             index=100,
         )
         expected = (
-            "Update the parent of tag (value=Tag 6) from parent (value=Tag 5)"
-            " to parent (external_id=tag_3)."
+            "Update the parent of <Tag> (31 / Tag 6) "
+            "from parent <Tag> (30 / Tag 5) to tag_3"
         )
         assert str(action) == expected
 

--- a/tests/openedx_tagging/core/tagging/import_export/test_actions.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_actions.py
@@ -283,15 +283,15 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
             "tag_4",
             "tag_3",
             (
-                "Update the parent of <Tag> (29 / tag_4 / Tag 4) "
-                "from parent <Tag> (28 / tag_3 / Tag 3) to tag_3"
+                "Update the parent of <Tag> (tag_4 / Tag 4) "
+                "from parent <Tag> (tag_3 / Tag 3) to tag_3"
             )
         ),
         (
             "tag_3",
             "tag_2",
             (
-                "Update the parent of <Tag> (28 / tag_3 / Tag 3) "
+                "Update the parent of <Tag> (tag_3 / Tag 3) "
                 "from parent None to tag_2"
             )
         ),
@@ -333,8 +333,8 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
             index=100,
         )
         expected = (
-            f"Update the parent of <Tag> ({tag_2.id} / Tag 6) "
-            f"from parent <Tag> ({tag_1.id} / Tag 5) to tag_3"
+            "Update the parent of <Tag> (Tag 6) "
+            "from parent <Tag> (Tag 5) to tag_3"
         )
         assert str(action) == expected
 

--- a/tests/openedx_tagging/core/tagging/import_export/test_actions.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_actions.py
@@ -334,7 +334,7 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
         )
         expected = (
             "Update the parent of <Tag> (31 / Tag 6) "
-            "from parent <Tag> (30 / Tag 5) to tag_3"
+            f"from parent <Tag> ({tag_1.id} / Tag 5) to tag_3"
         )
         assert str(action) == expected
 

--- a/tests/openedx_tagging/core/tagging/import_export/test_actions.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_actions.py
@@ -333,7 +333,7 @@ class TestUpdateParentTag(TestImportActionMixin, TestCase):
             index=100,
         )
         expected = (
-            "Update the parent of <Tag> (31 / Tag 6) "
+            f"Update the parent of <Tag> ({tag_2.id} / Tag 6) "
             f"from parent <Tag> ({tag_1.id} / Tag 5) to tag_3"
         )
         assert str(action) == expected

--- a/tests/openedx_tagging/core/tagging/import_export/test_api.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_api.py
@@ -215,6 +215,37 @@ class TestImportExportApi(TestImportExportMixin, TestCase):
                     assert new_tag.parent
                     assert tag.parent.external_id == new_tag.parent.external_id
 
+    def test_import_removing_no_external_id(self) -> None:
+        new_taxonomy = Taxonomy(name="New taxonomy")
+        new_taxonomy.save()
+        tag1 = Tag.objects.create(
+            id=1000,
+            value="Tag 1",
+            taxonomy=new_taxonomy,
+        )
+        tag2 = Tag.objects.create(
+            id=1001,
+            value="Tag 2",
+            taxonomy=new_taxonomy,
+        )
+        tag3 = Tag.objects.create(
+            id=1002,
+            value="Tag 3",
+            taxonomy=new_taxonomy,
+        )
+        tag1.save()
+        tag2.save()
+        tag3.save()
+        # Import with empty tags, to remove all tags
+        importFile = BytesIO(json.dumps({"tags": []}).encode())
+        result, _tasks, _plan = import_export_api.import_tags(
+            new_taxonomy,
+            importFile,
+            ParserFormat.JSON,
+            replace=True,
+        )
+        assert result
+
     def test_import_removing_with_childs(self) -> None:
         """
         Test import need to remove childs with parents that will also be removed
@@ -247,9 +278,48 @@ class TestImportExportApi(TestImportExportMixin, TestCase):
 
         # Import with empty tags, to remove all tags
         importFile = BytesIO(json.dumps({"tags": []}).encode())
-        assert import_export_api.import_tags(
+        result, _tasks, _plan = import_export_api.import_tags(
             new_taxonomy,
             importFile,
             ParserFormat.JSON,
             replace=True,
         )
+        assert result
+
+    def test_import_removing_with_childs_no_external_id(self) -> None:
+        """
+        Test import need to remove childs with parents that will also be removed,
+        using tags without external_id
+        """
+        new_taxonomy = Taxonomy(name="New taxonomy")
+        new_taxonomy.save()
+        level2 = Tag.objects.create(
+            id=1000,
+            value="Tag 2",
+            taxonomy=new_taxonomy,
+        )
+        level1 = Tag.objects.create(
+            id=1001,
+            value="Tag 1",
+            taxonomy=new_taxonomy,
+        )
+        level3 = Tag.objects.create(
+            id=1002,
+            value="Tag 3",
+            taxonomy=new_taxonomy,
+        )
+        level2.parent = level1
+        level2.save()
+
+        level3.parent = level3
+        level3.save()
+
+        # Import with empty tags, to remove all tags
+        importFile = BytesIO(json.dumps({"tags": []}).encode())
+        result, _tasks, _plan = import_export_api.import_tags(
+            new_taxonomy,
+            importFile,
+            ParserFormat.JSON,
+            replace=True,
+        )
+        assert result

--- a/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
@@ -251,13 +251,13 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             "--------------------------------\n"
             "#1: Create a new tag with values (external_id=tag_31, value=Tag 31, parent_id=None).\n"
             "#2: Create a new tag with values (external_id=tag_31, value=Tag 32, parent_id=None).\n"
-            "#3: Rename tag value of <Tag> (26 / tag_1 / Tag 1) to 'Tag 2'\n"
-            "#4: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
-            "<Tag> (28 / tag_3 / Tag 3) to tag_100\n"
+            "#3: Rename tag value of <Tag> (tag_1 / Tag 1) to 'Tag 2'\n"
+            "#4: Update the parent of <Tag> (tag_4 / Tag 4) from parent "
+            "<Tag> (tag_3 / Tag 3) to tag_100\n"
             "#5: Create a new tag with values (external_id=tag_33, value=Tag 32, parent_id=None).\n"
-            "#6: Update the parent of <Tag> (27 / tag_2 / Tag 2) from parent "
-            "<Tag> (26 / tag_1 / Tag 1) to None\n"
-            "#7: Rename tag value of <Tag> (27 / tag_2 / Tag 2) to 'Tag 31'\n"
+            "#6: Update the parent of <Tag> (tag_2 / Tag 2) from parent "
+            "<Tag> (tag_1 / Tag 1) to None\n"
+            "#7: Rename tag value of <Tag> (tag_2 / Tag 2) to 'Tag 31'\n"
             "\nOutput errors\n"
             "--------------------------------\n"
             "Conflict with 'create' (#2) and action #1: Duplicated external_id tag.\n"
@@ -299,10 +299,10 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             "--------------------------------\n"
             "#1: Create a new tag with values (external_id=tag_31, value=Tag 31, parent_id=None).\n"
             "#2: Create a new tag with values (external_id=tag_32, value=Tag 32, parent_id=tag_1).\n"
-            "#3: Rename tag value of <Tag> (27 / tag_2 / Tag 2) to 'Tag 2 v2'\n"
-            "#4: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
-            "<Tag> (28 / tag_3 / Tag 3) to tag_1\n"
-            "#5: Rename tag value of <Tag> (29 / tag_4 / Tag 4) to 'Tag 4 v2'\n"
+            "#3: Rename tag value of <Tag> (tag_2 / Tag 2) to 'Tag 2 v2'\n"
+            "#4: Update the parent of <Tag> (tag_4 / Tag 4) from parent "
+            "<Tag> (tag_3 / Tag 3) to tag_1\n"
+            "#5: Rename tag value of <Tag> (tag_4 / Tag 4) to 'Tag 4 v2'\n"
             "#6: No changes needed for <TagItem> (tag_1 / Tag 1)\n"
         ),
         # Testing deletes (replace=True)
@@ -315,18 +315,14 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
                 },
             ],
             True,
-            # ToDo: Change the lines below when https://github.com/openedx/openedx-learning/pull/135 is merged
             "Import plan for Import Taxonomy Test\n"
             "--------------------------------\n"
-            "#1: Delete tag (external_id=tag_1)\n"
-            "#2: Delete tag (external_id=tag_2)\n"
-            "#3: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
-            "<Tag> (28 / tag_3 / Tag 3) to None\n"
-            # "#3: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
-            # "<Tag> (28 / tag_3 / Tag 3) to None\n"
-            "#4: Delete tag (external_id=tag_3)\n"
+            "#1: Delete tag <TagItem> (tag_1 / Tag 1)\n"
+            "#2: Delete tag <TagItem> (tag_2 / Tag 2)\n"
+            "#3: Update the parent of <Tag> (tag_4 / Tag 4) from parent "
+            "<Tag> (tag_3 / Tag 3) to None\n"
+            "#4: Delete tag <TagItem> (tag_3 / Tag 3)\n"
             "#5: No changes needed for <TagItem> (tag_4 / Tag 4)\n"
-            # "#5: No changes needed for <TagItem> (tag_4 / Tag 4)\n"
         ),
     )
     @ddt.unpack
@@ -340,6 +336,7 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
         tags = [TagItem(**tag) for tag in tags]
         self.import_plan.generate_actions(tags=tags, replace=replace)
         plan = self.import_plan.plan()
+        print(plan)
         assert plan == expected
 
     @ddt.data(

--- a/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
@@ -251,13 +251,13 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             "--------------------------------\n"
             "#1: Create a new tag with values (external_id=tag_31, value=Tag 31, parent_id=None).\n"
             "#2: Create a new tag with values (external_id=tag_31, value=Tag 32, parent_id=None).\n"
-            "#3: Rename tag value of tag (external_id=tag_1) from 'Tag 1' to 'Tag 2'\n"
-            "#4: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
-            "to parent (external_id=tag_100).\n"
+            "#3: Rename tag value of <Tag> (26 / tag_1 / Tag 1) to 'Tag 2'\n"
+            "#4: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
+            "<Tag> (28 / tag_3 / Tag 3) to tag_100\n"
             "#5: Create a new tag with values (external_id=tag_33, value=Tag 32, parent_id=None).\n"
-            "#6: Update the parent of tag (external_id=tag_2) from parent (external_id=tag_1) "
-            "to parent (external_id=None).\n"
-            "#7: Rename tag value of tag (external_id=tag_2) from 'Tag 2' to 'Tag 31'\n"
+            "#6: Update the parent of <Tag> (27 / tag_2 / Tag 2) from parent "
+            "<Tag> (26 / tag_1 / Tag 1) to None\n"
+            "#7: Rename tag value of <Tag> (27 / tag_2 / Tag 2) to 'Tag 31'\n"
             "\nOutput errors\n"
             "--------------------------------\n"
             "Conflict with 'create' (#2) and action #1: Duplicated external_id tag.\n"
@@ -299,11 +299,11 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             "--------------------------------\n"
             "#1: Create a new tag with values (external_id=tag_31, value=Tag 31, parent_id=None).\n"
             "#2: Create a new tag with values (external_id=tag_32, value=Tag 32, parent_id=tag_1).\n"
-            "#3: Rename tag value of tag (external_id=tag_2) from 'Tag 2' to 'Tag 2 v2'\n"
-            "#4: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
-            "to parent (external_id=tag_1).\n"
-            "#5: Rename tag value of tag (external_id=tag_4) from 'Tag 4' to 'Tag 4 v2'\n"
-            "#6: No changes needed for tag (external_id=tag_1)\n"
+            "#3: Rename tag value of <Tag> (27 / tag_2 / Tag 2) to 'Tag 2 v2'\n"
+            "#4: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
+            "<Tag> (28 / tag_3 / Tag 3) to tag_1\n"
+            "#5: Rename tag value of <Tag> (29 / tag_4 / Tag 4) to 'Tag 4 v2'\n"
+            "#6: No changes needed for <TagItem> (tag_1 / Tag 1)\n"
         ),
         # Testing deletes (replace=True)
         (
@@ -317,11 +317,11 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             True,
             "Import plan for Import Taxonomy Test\n"
             "--------------------------------\n"
-            "#1: No changes needed for tag (external_id=tag_4)\n"
+            "#1: No changes needed for <TagItem> (tag_4 / Tag 4)\n"
             "#2: Delete tag (external_id=tag_1)\n"
             "#3: Delete tag (external_id=tag_2)\n"
-            "#4: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
-            "to parent (external_id=None).\n"
+            "#4: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
+            "<Tag> (28 / tag_3 / Tag 3) to None\n"
             "#5: Delete tag (external_id=tag_3)\n"
         ),
     )
@@ -336,7 +336,6 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
         tags = [TagItem(**tag) for tag in tags]
         self.import_plan.generate_actions(tags=tags, replace=replace)
         plan = self.import_plan.plan()
-        print(plan)
         assert plan == expected
 
     @ddt.data(

--- a/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
@@ -336,7 +336,6 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
         tags = [TagItem(**tag) for tag in tags]
         self.import_plan.generate_actions(tags=tags, replace=replace)
         plan = self.import_plan.plan()
-        print(plan)
         assert plan == expected
 
     @ddt.data(

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -178,7 +178,7 @@ class TestTagTaxonomy(TestTagTaxonomyMixin, TestCase):
             == repr(self.language_taxonomy)
             == "<LanguageTaxonomy> (-1) Languages"
         )
-        assert str(self.bacteria) == repr(self.bacteria) == "<Tag> (1 / Bacteria)"
+        assert str(self.bacteria) == repr(self.bacteria) == "<Tag> (1) Bacteria"
 
     def test_taxonomy_cast(self):
         for subclass in (

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -178,7 +178,7 @@ class TestTagTaxonomy(TestTagTaxonomyMixin, TestCase):
             == repr(self.language_taxonomy)
             == "<LanguageTaxonomy> (-1) Languages"
         )
-        assert str(self.bacteria) == repr(self.bacteria) == "<Tag> (1) Bacteria"
+        assert str(self.bacteria) == repr(self.bacteria) == "<Tag> (1 / Bacteria)"
 
     def test_taxonomy_cast(self):
         for subclass in (

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2463,7 +2463,6 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
             + "#4: Create a new tag with values (external_id=tag_2, value=Tag 2, parent_id=None).\n" \
             + "#5: Create a new tag with values (external_id=tag_3, value=Tag 3, parent_id=None).\n" \
             + "#6: Create a new tag with values (external_id=tag_4, value=Tag 4, parent_id=None).\n"
-        print(response.data["plan"])
         assert response.data["plan"] == expected_plan
 
         self._check_taxonomy_not_changed()

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2457,12 +2457,13 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.data["task"]["status"] == "success"
         expected_plan = "Import plan for Test import taxonomy\n" \
             + "--------------------------------\n" \
-            + "#1: Delete tag (external_id=old_tag_1)\n" \
-            + "#2: Delete tag (external_id=old_tag_2)\n" \
+            + "#1: Delete tag <TagItem> (old_tag_1 / Old tag 1)\n" \
+            + "#2: Delete tag <TagItem> (old_tag_2 / Old tag 2)\n" \
             + "#3: Create a new tag with values (external_id=tag_1, value=Tag 1, parent_id=None).\n" \
             + "#4: Create a new tag with values (external_id=tag_2, value=Tag 2, parent_id=None).\n" \
             + "#5: Create a new tag with values (external_id=tag_3, value=Tag 3, parent_id=None).\n" \
             + "#6: Create a new tag with values (external_id=tag_4, value=Tag 4, parent_id=None).\n"
+        print(response.data["plan"])
         assert response.data["plan"] == expected_plan
 
         self._check_taxonomy_not_changed()


### PR DESCRIPTION
## Description
This fix an error when it comes to performing actions on a taxonomy with tags that have `external_id=None`

## More info
Part of: https://github.com/openedx/modular-learning/issues/126

## Testing instructions
Please ensure that the tests cover the expected behavior

## After merge
- [ ] Create a tag to upload the new version