### PR TITLE
fix: bug importing tags with the same value as an existing one

### DIFF
--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -49,7 +49,7 @@ class TagImportPlan:
         for action in available_actions:
             self.indexed_actions[action.name] = []
 
-    def _build_action(self, action_cls, tag: TagItem):
+    def _build_action(self, action_cls: type[ImportAction], tag: TagItem):
         """
         Build an action with `tag`.
 
@@ -139,6 +139,13 @@ class TagImportPlan:
                 tag.external_id: tag for tag in self.taxonomy.tag_set.all()
             }
 
+            for tag in tags:
+                if tag.id in tags_for_delete:
+                    tags_for_delete.pop(tag.id)
+
+            # Delete all not readed tags
+            self._build_delete_actions(tags_for_delete)
+
         for tag in tags:
             has_action = False
 
@@ -151,13 +158,6 @@ class TagImportPlan:
             if not has_action:
                 # If it doesn't find an action, a "without changes" is added
                 self._build_action(WithoutChanges, tag)
-
-            if replace and tag.id in tags_for_delete:
-                tags_for_delete.pop(tag.id)
-
-        if replace:
-            # Delete all not readed tags
-            self._build_delete_actions(tags_for_delete)
 
     def plan(self) -> str:
         """

--- a/tests/openedx_tagging/core/tagging/import_export/test_api.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_api.py
@@ -253,3 +253,25 @@ class TestImportExportApi(TestImportExportMixin, TestCase):
             ParserFormat.JSON,
             replace=True,
         )
+
+    def test_import_same_value_without_external_id(self) -> None:
+        new_taxonomy = Taxonomy(name="New taxonomy")
+        new_taxonomy.save()
+
+        # Tag with no external_id
+        Tag.objects.create(
+            value="same_value",
+            taxonomy=new_taxonomy,
+        )
+
+        # Import with one tag with the same value
+        importFile = BytesIO(json.dumps({"tags": [{"id": "imported_tag", "value": "same_value"}]}).encode())
+
+        result, _tasks, _plan = import_export_api.import_tags(
+            new_taxonomy,
+            importFile,
+            ParserFormat.JSON,
+            replace=True,
+        )
+
+        assert result

--- a/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
+++ b/tests/openedx_tagging/core/tagging/import_export/test_import_plan.py
@@ -182,10 +182,6 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
             0,
             [
                 {
-                    'name': 'without_changes',
-                    'id': 'tag_4',
-                },
-                {
                     'name': 'delete',
                     'id': 'tag_1',
                 },
@@ -200,6 +196,10 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
                 {
                     'name': 'delete',
                     'id': 'tag_3',
+                },
+                {
+                    'name': 'without_changes',
+                    'id': 'tag_4',
                 },
             ]
         )
@@ -315,14 +315,18 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
                 },
             ],
             True,
+            # ToDo: Change the lines below when https://github.com/openedx/openedx-learning/pull/135 is merged
             "Import plan for Import Taxonomy Test\n"
             "--------------------------------\n"
-            "#1: No changes needed for tag (external_id=tag_4)\n"
-            "#2: Delete tag (external_id=tag_1)\n"
-            "#3: Delete tag (external_id=tag_2)\n"
-            "#4: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
+            "#1: Delete tag (external_id=tag_1)\n"
+            "#2: Delete tag (external_id=tag_2)\n"
+            "#3: Update the parent of tag (external_id=tag_4) from parent (external_id=tag_3) "
             "to parent (external_id=None).\n"
-            "#5: Delete tag (external_id=tag_3)\n"
+            # "#3: Update the parent of <Tag> (29 / tag_4 / Tag 4) from parent "
+            # "<Tag> (28 / tag_3 / Tag 3) to None\n"
+            "#4: Delete tag (external_id=tag_3)\n"
+            "#5: No changes needed for tag (external_id=tag_4)\n"
+            # "#5: No changes needed for <TagItem> (tag_4 / Tag 4)\n"
         ),
     )
     @ddt.unpack
@@ -336,7 +340,6 @@ class TestTagImportPlan(TestImportActionMixin, TestCase):
         tags = [TagItem(**tag) for tag in tags]
         self.import_plan.generate_actions(tags=tags, replace=replace)
         plan = self.import_plan.plan()
-        print(plan)
         assert plan == expected
 
     @ddt.data(

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -2457,12 +2457,12 @@ class TestImportTagsView(ImportTaxonomyMixin, APITestCase):
         assert response.data["task"]["status"] == "success"
         expected_plan = "Import plan for Test import taxonomy\n" \
             + "--------------------------------\n" \
-            + "#1: Create a new tag with values (external_id=tag_1, value=Tag 1, parent_id=None).\n" \
-            + "#2: Create a new tag with values (external_id=tag_2, value=Tag 2, parent_id=None).\n" \
-            + "#3: Create a new tag with values (external_id=tag_3, value=Tag 3, parent_id=None).\n" \
-            + "#4: Create a new tag with values (external_id=tag_4, value=Tag 4, parent_id=None).\n" \
-            + "#5: Delete tag (external_id=old_tag_1)\n" \
-            + "#6: Delete tag (external_id=old_tag_2)\n"
+            + "#1: Delete tag (external_id=old_tag_1)\n" \
+            + "#2: Delete tag (external_id=old_tag_2)\n" \
+            + "#3: Create a new tag with values (external_id=tag_1, value=Tag 1, parent_id=None).\n" \
+            + "#4: Create a new tag with values (external_id=tag_2, value=Tag 2, parent_id=None).\n" \
+            + "#5: Create a new tag with values (external_id=tag_3, value=Tag 3, parent_id=None).\n" \
+            + "#6: Create a new tag with values (external_id=tag_4, value=Tag 4, parent_id=None).\n"
         assert response.data["plan"] == expected_plan
 
         self._check_taxonomy_not_changed()


### PR DESCRIPTION
## Description
If we try to import tags over a taxonomy that shares the same Tag Value, an error is thrown about the conflict tag value.

It can be reproduced by importing the Template Taxonomy over the "Lightcast Open Skills Taxonomy".
Both taxonomies have a tag with the value "piano". In the plan, it tries to create the tag piano for the Template before deleting the one from Lightcast, raising an error.

This PR changes the order of the import actions, always running the DeleteTag actions before others to avoid this.

## Testing Instructions
Please ensure that the tests cover the expected behavior.

---
Private-ref:
 - [FAL-3603](https://tasks.opencraft.com/browse/FAL-3603)