### PR TITLE
Change PublishableEntity key convention to match v2 lib conventions (v 0.6.1)

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/openedx_learning/core/components/api.py
+++ b/openedx_learning/core/components/api.py
@@ -51,7 +51,7 @@ def create_component(
     """
     Create a new Component (an entity like a Problem or Video)
     """
-    key = f"{component_type.namespace}:{component_type.name}@{local_key}"
+    key = f"{component_type.namespace}:{component_type.name}:{local_key}"
     with atomic():
         publishable_entity = publishing_api.create_publishable_entity(
             learning_package_id, key, created, created_by

--- a/tests/openedx_learning/core/components/test_api.py
+++ b/tests/openedx_learning/core/components/test_api.py
@@ -310,6 +310,10 @@ class ComponentGetAndExistsTestCase(ComponentTestCase):
         with self.assertRaises(ObjectDoesNotExist):
             components_api.get_component(-1)
 
+    def test_publishing_entity_key_convention(self):
+        """Our mapping convention is {namespace}:{component_type}:{local_key}"""
+        assert self.problem.key == "xblock.v1:problem:my_component"
+
     def test_get_by_key(self):
         assert self.html == components_api.get_component_by_key(
             self.learning_package.id,


### PR DESCRIPTION
Also bumps the version to 0.6.1.

```
fix: map PublishableEntity keys to library conventions

PublishableEntities have their own "key" field that must be unique
within a LearningPackage. Components are PublishableEntities (via 1:1
relationship), but they store that data as separate fields that are
useful for filtering and grouping on. When we create a Component, it
creates a PublishableEntity key value based on its own namespace, type,
and local key.

Before this commit, we followed a more ModuleStore-like convention and
the derived key would have its type and local key separated by "@":

  xblock.v1:html@424337d3-e1fc-4970-822a-684b1ccb0c1d

This commit changes it so that we follow the v2 libraries convention of
having a ":" between the two instead:

  xblock.v1:html:424337d3-e1fc-4970-822a-684b1ccb0c1d
```