### PR TITLE
feat: add get_taxonomy_by_export_id method [FC-0049]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -67,6 +67,14 @@ def get_taxonomy(taxonomy_id: int) -> Taxonomy | None:
     return taxonomy.cast() if taxonomy else None
 
 
+def get_taxonomy_by_export_id(taxonomy_export_id: str) -> Taxonomy | None:
+    """
+    Returns a Taxonomy cast to the appropriate subclass which has the given export ID.
+    """
+    taxonomy = Taxonomy.objects.filter(export_id=taxonomy_export_id).first()
+    return taxonomy.cast() if taxonomy else None
+
+
 def get_taxonomies(enabled=True) -> QuerySet[Taxonomy]:
     """
     Returns a queryset containing the enabled taxonomies, sorted by name.

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -241,7 +241,7 @@ class Taxonomy(models.Model):
             "Indicates whether this taxonomy should be visible to object authors."
         ),
     )
-    # Export ID that should only be used on import/export.
+    # External ID that should only be used on import/export.
     # NOT use for any other purposes, you can use the numeric ID of the model instead;
     # this id is editable.
     export_id = models.CharField(

--- a/openedx_tagging/core/tagging/models/base.py
+++ b/openedx_tagging/core/tagging/models/base.py
@@ -241,7 +241,7 @@ class Taxonomy(models.Model):
             "Indicates whether this taxonomy should be visible to object authors."
         ),
     )
-    # External ID that should only be used on import/export.
+    # Export ID that should only be used on import/export.
     # NOT use for any other purposes, you can use the numeric ID of the model instead;
     # this id is editable.
     export_id = models.CharField(

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -88,6 +88,13 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
         no_tax = tagging_api.get_taxonomy(200)
         assert no_tax is None
 
+    def test_get_taxonomy_by_export_id(self) -> None:
+        tax1 = tagging_api.get_taxonomy_by_export_id("life_on_earth")
+        assert tax1 == self.taxonomy
+
+        no_tax = tagging_api.get_taxonomy_by_export_id("nope")
+        assert no_tax is None
+
     def test_get_taxonomies(self) -> None:
         tax1 = tagging_api.create_taxonomy("Enabled")
         tax2 = tagging_api.create_taxonomy("Disabled", enabled=False)


### PR DESCRIPTION
## Description

This PR adds a `get_taxonomy_by_export_id` method. This method will be used in to import taxonomy data.

## Supporting information
- Part of: https://github.com/openedx/modular-learning/issues/180

## Testing Instructions
- Please ensure that the tests cover the expected behavior

___
Private ref: [FAL-3621](https://tasks.opencraft.com/browse/FAL-3621)