### PR TITLE
[FC-0036] feat: Update ObjectTagView

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -191,22 +191,21 @@ class ObjectTagsByTaxonomySerializer(UserPermissionsSerializerMixin, serializers
         return by_object
 
 
+class ObjectTagUpdateByTaxonomySerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer of a taxonomy item of ObjectTag UPDATE view.
+    """
+    taxonomy = serializers.PrimaryKeyRelatedField(
+        queryset=Taxonomy.objects.all(), required=True
+    )
+    tags = serializers.ListField(child=serializers.CharField(), required=True)
+
+
 class ObjectTagUpdateBodySerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
     Serializer of the body for the ObjectTag UPDATE view
     """
-
-    tags = serializers.ListField(child=serializers.CharField(), required=True)
-
-
-class ObjectTagUpdateQueryParamsSerializer(serializers.Serializer):  # pylint: disable=abstract-method
-    """
-    Serializer of the query params for the ObjectTag UPDATE view
-    """
-
-    taxonomy = serializers.PrimaryKeyRelatedField(
-        queryset=Taxonomy.objects.all(), required=True
-    )
+    tagsData = serializers.ListField(child=ObjectTagUpdateByTaxonomySerializer(), required=True)
 
 
 class TagDataSerializer(UserPermissionsSerializerMixin, serializers.Serializer):  # pylint: disable=abstract-method

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -565,9 +565,10 @@ class ObjectTagView(
                 # The obj arg expects a model, but we are passing an object
                 perm_obj,  # type: ignore[arg-type]
             ):
-                raise PermissionDenied(
-                    f"You do not have permission to change object tags for {str(taxonomy)} or object_id."
-                )
+                raise PermissionDenied(f"""
+                    You do not have permission to change object tags
+                    for Taxonomy: {str(taxonomy)} or Object: {object_id}.
+                """)
 
         # Tag object_id per taxonomy
         for tagsData in data:

--- a/tests/openedx_tagging/core/tagging/test_models.py
+++ b/tests/openedx_tagging/core/tagging/test_models.py
@@ -40,6 +40,7 @@ class TestTagTaxonomyMixin:
         self.language_taxonomy = LanguageTaxonomy.objects.get(name="Languages")
         self.user_taxonomy = Taxonomy.objects.get(name="User Authors").cast()
         self.free_text_taxonomy = api.create_taxonomy(name="Free Text", allow_free_text=True)
+        self.import_taxonomy = Taxonomy.objects.get(name="Import Taxonomy Test")
 
         # References to some tags:
         self.archaea = get_tag("Archaea")


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳


Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

Updates ObjectTagView Put request to update multiple taxonomies in one request

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/190
- Related PRs:
    - https://github.com/openedx/frontend-app-course-authoring/pull/939
    - https://github.com/openedx/edx-platform/pull/34490
- Internal ticket: [FAL-3645](https://tasks.opencraft.com/browse/FAL-3645)

## Testing instructions

- Follow the testing instructions of https://github.com/openedx/frontend-app-course-authoring/pull/939

