### PR TITLE
[FC-0049] feat: Update permissions to remove object tags

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -140,7 +140,14 @@ class ObjectTagMinimalSerializer(UserPermissionsSerializerMixin, serializers.Mod
         fields = ["value", "lineage", "can_delete_objecttag"]
 
     lineage = serializers.ListField(child=serializers.CharField(), source="get_lineage", read_only=True)
-    can_delete_objecttag = serializers.SerializerMethodField(method_name='get_can_delete')
+    can_delete_objecttag = serializers.SerializerMethodField()
+
+    def get_can_delete_objecttag(self, instance) -> bool | None:
+        """
+        Returns True if the current request user may delete object tags on this taxonomy
+        """
+        perm_name = f'{self.app_label}.remove_objecttag_objectid'
+        return self._can(perm_name, instance.object_id)
 
 
 class ObjectTagSerializer(ObjectTagMinimalSerializer):

--- a/openedx_tagging/core/tagging/rules.py
+++ b/openedx_tagging/core/tagging/rules.py
@@ -100,6 +100,16 @@ def can_view_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
 
 
 @rules.predicate
+def can_remove_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
+    """
+    Everybody can remove object tags from any objects.
+
+    This rule could be defined in other apps for proper permission checking.
+    """
+    return True
+
+
+@rules.predicate
 def can_view_object_tag(
     user: UserType, perm_obj: ObjectTagPermissionItem | None = None
 ) -> bool:
@@ -194,3 +204,4 @@ rules.add_perm("oel_tagging.view_objecttag_objectid", can_view_object_tag_object
 rules.add_perm("oel_tagging.view_objecttag_taxonomy", can_view_object_tag_taxonomy)
 rules.add_perm("oel_tagging.change_objecttag_taxonomy", can_view_object_tag_taxonomy)
 rules.add_perm("oel_tagging.change_objecttag_objectid", can_change_object_tag_objectid)
+rules.add_perm("oel_tagging.remove_objecttag_objectid", can_remove_object_tag_objectid)

--- a/openedx_tagging/core/tagging/rules.py
+++ b/openedx_tagging/core/tagging/rules.py
@@ -100,16 +100,6 @@ def can_view_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
 
 
 @rules.predicate
-def can_remove_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
-    """
-    Everybody can remove object tags from any objects.
-
-    This rule could be defined in other apps for proper permission checking.
-    """
-    return True
-
-
-@rules.predicate
 def can_view_object_tag(
     user: UserType, perm_obj: ObjectTagPermissionItem | None = None
 ) -> bool:
@@ -145,6 +135,16 @@ def can_change_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
     This rule should be defined in other apps for proper permission checking.
     """
     return False
+
+
+@rules.predicate
+def can_remove_object_tag_objectid(_user: UserType, _object_id: str) -> bool:
+    """
+    Nobody can remove object tags without checking the permission for the tagged object.
+
+    This rule could be defined in other apps for proper permission checking.
+    """
+    return can_change_object_tag_objectid(_user, _object_id)
 
 
 @rules.predicate

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -767,12 +767,12 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
                                 {
                                     "value": "Mammalia",
                                     "lineage": ["Eukaryota", "Animalia", "Chordata", "Mammalia"],
-                                    "can_delete_objecttag": True,
+                                    "can_delete_objecttag": False,
                                 },
                                 {
                                     "value": "Fungi",
                                     "lineage": ["Eukaryota", "Fungi"],
-                                    "can_delete_objecttag": True,
+                                    "can_delete_objecttag": False,
                                 },
                             ],
                             "export_id": "life_on_earth"
@@ -785,7 +785,7 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
                                 {
                                     "value": "test_user_1",
                                     "lineage": ["test_user_1"],
-                                    "can_delete_objecttag": True,
+                                    "can_delete_objecttag": False,
                                 },
                             ],
                             "export_id": "user_authors"
@@ -860,7 +860,7 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
         Test the sort order of the object tags retrieved from the get object
         tags API.
         """
-        object_id, sort_test_applied_result = self.prepare_for_sort_test(expected_perm=True)
+        object_id, sort_test_applied_result = self.prepare_for_sort_test(expected_perm=False)
 
         url = OBJECT_TAGS_RETRIEVE_URL.format(object_id=object_id)
         self.client.force_authenticate(user=self.user_1)
@@ -874,7 +874,8 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
         Test how many queries are used when retrieving object tags and permissions
         """
         expected_perm = True
-        object_id, sort_test_applied_result = self.prepare_for_sort_test(expected_perm)
+        expoected_remove_perm = False
+        object_id, sort_test_applied_result = self.prepare_for_sort_test(expoected_remove_perm)
         url = OBJECT_TAGS_RETRIEVE_URL.format(object_id=object_id)
 
         self.client.force_authenticate(user=self.user_1)
@@ -936,7 +937,7 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
                                 {
                                     "value": "test_user_1",
                                     "lineage": ["test_user_1"],
-                                    "can_delete_objecttag": True,
+                                    "can_delete_objecttag": False,
                                 },
                             ],
                             "export_id": "user_authors",

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -874,8 +874,8 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
         Test how many queries are used when retrieving object tags and permissions
         """
         expected_perm = True
-        expoected_remove_perm = False
-        object_id, sort_test_applied_result = self.prepare_for_sort_test(expoected_remove_perm)
+        expected_remove_perm = False
+        object_id, sort_test_applied_result = self.prepare_for_sort_test(expected_remove_perm)
         url = OBJECT_TAGS_RETRIEVE_URL.format(object_id=object_id)
 
         self.client.force_authenticate(user=self.user_1)


### PR DESCRIPTION
## Description

This updates rules to add `can_remove_object_tag_objectid` to Objet tag views

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/204
- Internal ticket: [FAL-3720](https://tasks.opencraft.com/browse/FAL-3720)

## Testing instructions

- Follow the testing instructions in https://github.com/openedx/frontend-app-course-authoring/pull/987