### PR TITLE
[FC-0049] fix: Issues when importing a large taxonomy

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.9.3"
+__version__ = "0.9.4"

--- a/openedx_tagging/core/tagging/import_export/actions.py
+++ b/openedx_tagging/core/tagging/import_export/actions.py
@@ -244,16 +244,13 @@ class CreateTag(ImportAction):
         """
         Creates a Tag
         """
-        parent = None
-        if self.tag.parent_id:
-            parent = self.taxonomy.tag_set.get(external_id=self.tag.parent_id)
-        taxonomy_tag = Tag(
+        Tag.objects.create(
             taxonomy=self.taxonomy,
-            parent=parent,
+            parent=self.taxonomy.tag_set.get(external_id=self.tag.parent_id)
+            if self.tag.parent_id is not None else None,
             value=self.tag.value,
             external_id=self.tag.id,
         )
-        taxonomy_tag.save()
 
 
 class UpdateParentTag(ImportAction):

--- a/openedx_tagging/core/tagging/import_export/actions.py
+++ b/openedx_tagging/core/tagging/import_export/actions.py
@@ -406,8 +406,7 @@ class DeleteTag(ImportAction):
         Delete a tag
         """
         try:
-            taxonomy_tag = self._get_tag()
-            taxonomy_tag.delete()
+            self._get_tag().delete()
         except Tag.DoesNotExist:
             pass  # The tag may be already cascade deleted if the parent tag was deleted
 

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -208,7 +208,7 @@ class TagImportPlan:
             return
         for action in self.actions:
             # Avoid to save each log because is slow and costs a lot in memory
-            # It is necessary to record at the end.
+            # It is necessary to save at the end.
             if task:
                 task.add_log(f"#{action.index}: {str(action)} [Started]", save=False)
             action.execute()

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -207,7 +207,7 @@ class TagImportPlan:
         if self.errors:
             return
         for action in self.actions:
-            # Avoid to save each log because is slow and costs a lot in memory
+            # Avoid to save each log because it is slow and costs a lot in memory
             # It is necessary to save at the end.
             if task:
                 task.add_log(f"#{action.index}: {str(action)} [Started]", save=False)

--- a/openedx_tagging/core/tagging/import_export/import_plan.py
+++ b/openedx_tagging/core/tagging/import_export/import_plan.py
@@ -207,8 +207,12 @@ class TagImportPlan:
         if self.errors:
             return
         for action in self.actions:
+            # Avoid to save each log because is slow and costs a lot in memory
+            # It is necessary to record at the end.
             if task:
-                task.add_log(f"#{action.index}: {str(action)} [Started]")
+                task.add_log(f"#{action.index}: {str(action)} [Started]", save=False)
             action.execute()
             if task:
-                task.add_log("Success")
+                task.add_log("Success", save=False)
+        if task:
+            task.save()

--- a/openedx_tagging/core/tagging/models/import_export.py
+++ b/openedx_tagging/core/tagging/models/import_export.py
@@ -90,11 +90,11 @@ class TagImportTask(models.Model):
         """
         self.add_log(_("Starting to load data from file"))
 
-    def log_parser_end(self):
+    def log_parser_end(self, elapsed_time):
         """
         Logs the parser finished event.
         """
-        self.add_log(_("Load data finished"))
+        self.add_log(_("Load data finished. Time elapsed: ") + str(elapsed_time) + _(" seconds"))
 
     def handle_parser_errors(self, errors):
         """
@@ -113,11 +113,11 @@ class TagImportTask(models.Model):
         self.status = TagImportTaskState.PLANNING.value
         self.save()
 
-    def log_plan(self, plan):
+    def log_plan(self, plan, elapsed_time):
         """
         Logs the task plan.
         """
-        self.add_log(_("Plan finished"))
+        self.add_log(_("Plan finished. Time elapsed: ") + str(elapsed_time) + _(" seconds"))
         plan_str = plan.plan()
         self.log += f"\n{plan_str}\n"
         self.save()
@@ -138,10 +138,13 @@ class TagImportTask(models.Model):
         self.status = TagImportTaskState.EXECUTING.value
         self.save()
 
-    def end_success(self):
+    def log_end_execute(self, elapsed_time):
+        self.add_log(_("Execute actions finished. Time elapsed: ") + str(elapsed_time) + _(" seconds"))
+
+    def end_success(self, elapsed_time):
         """
         Completes task execution with a log message, and moves the task status to SUCCESS.
         """
-        self.add_log(_("Execution finished"), save=False)
+        self.add_log(_("Execution finished. Total time elapsed: ") + str(elapsed_time) + _("seconds"), save=False)
         self.status = TagImportTaskState.SUCCESS.value
         self.save()


### PR DESCRIPTION
## Description

* Adds time elapsed to import log.
* Fix issues with memory and time when importing a large taxonomy.

## Supporting information

- Github issue: https://github.com/openedx/modular-learning/issues/213
- Related to: https://github.com/openedx/edx-platform/pull/34796
- Internal ticket: https://tasks.opencraft.com/browse/FAL-3721

It has been tested with taxonomies that take too long or could not finish due to a memory backup. These are their average times after fixing the issue:

- `WGU Instructional Design: K-12 Collection`: 5.95 seconds.
- `FlatTaxonomy`: 65.55 seconds.
- `Lightcast Open Skills Taxonomy`: 76.5 seconds.

## Testing instructions

- Use this branch of `edx-platform`: https://github.com/openedx/edx-platform/pull/34796
- Run `make requirements` on cms-shell
- Ensure you have the testing data: https://github.com/open-craft/taxonomy-sample-data
- Export this taxonomies:
    - `WGU Instructional Design`
    - `FlatTaxonomy`
    - `Lightcast Open Skills Taxonomy`
- Import a new taxonomy using the previous exported files.
- After every import:
    - Ensure that the memory is linear constant and there is not a memory overflow.
    - Go to python cms bash and run the code. Check the elapsed time.

```
from openedx_tagging.core.tagging.models.import_export import TagImportTask
task = list(TagImportTask.objects.all())[-1]
task.log
```

