### PR TITLE
Remove Django 3.2 collations compatibility hack

### DIFF
--- a/openedx_learning/lib/collations.py
+++ b/openedx_learning/lib/collations.py
@@ -36,48 +36,6 @@ class MultiCollationMixin:
         super().__init__(*args, **kwargs)
         self.db_collations = db_collations or {}
 
-        # This is part of a hack to get this to work for Django < 4.1. Please
-        # see comments in the db_collation method for details.
-        self._vendor = None
-
-    @property
-    def db_collation(self):
-        """
-        Return the db_collation, understanding that it varies by vendor.
-
-        This method is a hack for Django 3.2 compatibility and should be removed
-        after we move to 4.2.
-
-        Description of why this is hacky:
-
-        In Django 4.2, the schema builder pulls the collation settings from the
-        field using the value returned from the ``db_parameters`` method, and
-        this does what we want it to do. In Django 3.2, field.db_parameters is
-        called, but any collation value sent back is ignored and the code grabs
-        the value of db_collation directly from the field:
-
-        https://github.com/django/django/blob/stable/3.2.x/django/db/backends/base/schema.py#L214-L224
-
-        But this call to get the ``field.db_collation`` attribute happens almost
-        immediately after the ``field.db_parameters`` method call. So our
-        fragile hack is to set ``self._vendor`` in the ``db_parameters`` method,
-        using the value we get from the connection that is passed in there. We
-        can then use ``self._vendor`` to return the right value when Django
-        calls ``field.db_collation`` (which is this property method).
-
-        This method, the corresponding setter, and all references to
-        ``self._vendor`` should be removed after we've cut over to Django 4.2.
-        """
-        return self.db_collations.get(self._vendor)
-
-    @db_collation.setter
-    def db_collation(self, value):
-        """
-        Don't allow db_collation to be set manually (just ignore).
-
-        This can be removed when we move to Django 4.2.
-        """
-
     def db_parameters(self, connection):
         """
         Return database parameters for this field. This adds collation info.
@@ -87,9 +45,6 @@ class MultiCollationMixin:
         'mysql' or 'sqlite'.
         """
         db_params = models.Field.db_parameters(self, connection)
-
-        # Remove once we no longer need to support Django < 4.1
-        self._vendor = connection.vendor
 
         # Now determine collation based on DB vendor (e.g. 'sqlite', 'mysql')
         if connection.vendor in self.db_collations:


### PR DESCRIPTION
Setting the collation via Field db_parameters was not properly supported before Django 4.x. We worked around this with a Django 3.2-compatible hack in https://github.com/ormsbee/openedx-learning/commit/084ec21a0292584f42f79930b6d6fe3bcf0ef08b. Now that we require at least Django 4.2, we no longer need the compatibility hack.