### PR TITLE
refactor: create_next_version -> create_next_component_version

### DIFF
--- a/openedx_learning/api/authoring.py
+++ b/openedx_learning/api/authoring.py
@@ -13,3 +13,8 @@ from ..apps.authoring.collections.api import *
 from ..apps.authoring.components.api import *
 from ..apps.authoring.contents.api import *
 from ..apps.authoring.publishing.api import *
+
+# This was renamed after the authoring API refactoring pushed this and other
+# app APIs into the openedx_learning.api.authoring module. Here I'm aliasing to
+# it's previous name, to make migration a little easier.
+create_next_version = create_next_component_version

--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -30,7 +30,7 @@ __all__ = [
     "get_or_create_component_type",
     "create_component",
     "create_component_version",
-    "create_next_version",
+    "create_next_component_version",
     "create_component_and_version",
     "get_component",
     "get_component_by_key",
@@ -109,7 +109,7 @@ def create_component_version(
     return component_version
 
 
-def create_next_version(
+def create_next_component_version(
     component_pk: int,
     /,
     title: str,

--- a/tests/openedx_learning/apps/authoring/components/test_api.py
+++ b/tests/openedx_learning/apps/authoring/components/test_api.py
@@ -414,7 +414,7 @@ class CreateNewVersionsTestCase(ComponentTestCase):
         )
 
         # Two text files, hello.txt and goodbye.txt
-        version_1 = components_api.create_next_version(
+        version_1 = components_api.create_next_component_version(
             self.problem.pk,
             title="Problem Version 1",
             content_to_replace={
@@ -440,7 +440,7 @@ class CreateNewVersionsTestCase(ComponentTestCase):
 
         # This should keep the old value for goodbye.txt, add blank.txt, and set
         # hello.txt to be a new value (blank).
-        version_2 = components_api.create_next_version(
+        version_2 = components_api.create_next_component_version(
             self.problem.pk,
             title="Problem Version 2",
             content_to_replace={
@@ -469,7 +469,7 @@ class CreateNewVersionsTestCase(ComponentTestCase):
 
         # Now we're going to set "hello.txt" back to hello_content, but remove
         # blank.txt, goodbye.txt, and an unknown "nothere.txt".
-        version_3 = components_api.create_next_version(
+        version_3 = components_api.create_next_component_version(
             self.problem.pk,
             title="Problem Version 3",
             content_to_replace={


### PR DESCRIPTION
Since the authoring apps now have their APIs aggregated into the public `openedx_learning.api.authoring` module, `create_next_version` will be ambiguous as soon as we create other versioned things like Units.

I'm including an alias to give more flexibility for switching edx-platform over.