### PR TITLE
Collections Django Admin + soft delete, hard delete, and restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ upgrade:  ## update the pip requirements files to use the latest releases satisf
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality
+	lint-imports
 
 pii_check: ## check for PII annotations on all Django models
 	tox -e pii_check

--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/openedx_learning/apps/authoring/collections/admin.py
+++ b/openedx_learning/apps/authoring/collections/admin.py
@@ -1,0 +1,27 @@
+"""
+Django Admin pages for Collection models.
+"""
+from django.contrib import admin
+
+from .models import Collection
+
+
+class CollectionAdmin(admin.ModelAdmin):
+    """
+    The Collection model admin.
+
+    Allows users to easily disable/enable (aka soft delete and restore) or bulk delete Collections.
+    """
+    readonly_fields = ["key", "learning_package"]
+    list_filter = ["enabled"]
+    list_display = ["key", "title", "enabled", "modified"]
+    list_editable = ["enabled"]
+
+    def has_add_permission(self, request, *args, **kwargs):
+        """
+        Disallow adding new collections via Django Admin.
+        """
+        return False  # pragma: no cover
+
+
+admin.site.register(Collection, CollectionAdmin)

--- a/openedx_learning/apps/authoring/collections/api.py
+++ b/openedx_learning/apps/authoring/collections/api.py
@@ -20,10 +20,12 @@ from .models import Collection
 __all__ = [
     "add_to_collection",
     "create_collection",
+    "delete_collection",
     "get_collection",
     "get_collections",
     "get_entity_collections",
     "remove_from_collection",
+    "restore_collection",
     "update_collection",
 ]
 
@@ -80,6 +82,42 @@ def update_collection(
     if description is not None:
         collection.description = description
 
+    collection.save()
+    return collection
+
+
+def delete_collection(
+    learning_package_id: int,
+    key: str,
+    *,
+    hard_delete=False,
+) -> Collection:
+    """
+    Disables or deletes a collection identified by the given learning_package + key.
+
+    By default (hard_delete=False), the collection is "soft deleted", i.e disabled.
+    Soft-deleted collections can be re-enabled using restore_collection.
+    """
+    collection = get_collection(learning_package_id, key)
+
+    if hard_delete:
+        collection.delete()
+    else:
+        collection.enabled = False
+        collection.save()
+    return collection
+
+
+def restore_collection(
+    learning_package_id: int,
+    key: str,
+) -> Collection:
+    """
+    Undo a "soft delete" by re-enabling a Collection.
+    """
+    collection = get_collection(learning_package_id, key)
+
+    collection.enabled = True
     collection.save()
     return collection
 

--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -42,6 +42,7 @@ __all__ = [
     "get_component_by_uuid",
     "get_component_version_by_uuid",
     "component_exists_by_key",
+    "get_collection_components",
     "get_components",
     "create_component_version_content",
     "look_up_component_version_content",
@@ -337,6 +338,21 @@ def get_components(
         )
 
     return qset
+
+
+def get_collection_components(
+    learning_package_id: int,
+    collection_key: str,
+) -> QuerySet[Component]:
+    """
+    Returns a QuerySet of Components relating to the PublishableEntities in a Collection.
+
+    Components have a one-to-one relationship with PublishableEntity, but the reverse may not always be true.
+    """
+    return Component.objects.filter(
+        learning_package_id=learning_package_id,
+        publishable_entity__collections__key=collection_key,
+    ).order_by('pk')
 
 
 def look_up_component_version_content(


### PR DESCRIPTION
## Description

Adds API methods for soft-deleting, hard-deleting and restoring Collections, and a Django Admin screen to allow superusers to hard delete any soft-deleted collections.

Also adds a convenience method `get_collection_components`, which makes it easier for ContentLibraries to interact with collection entities.

![image](https://github.com/user-attachments/assets/c57c260e-4c2f-41bb-81ab-41366f39ef2a)

## Supporting information

Related to: https://github.com/openedx/modular-learning/issues/231
Private-ref: [FAL-3809](https://tasks.opencraft.com/browse/FAL-3809)

## Testing instructions

1. Using the API, create a couple collections (`python manage.py shell`):
   ```python
   from openedx_learning.authoring import api
   learning_package = api.create_learning_package("FAL-3809", "Learning package for FAL-3809")
   api.create_collection(learning_package.id, "FAL-3809-1", title="Collection 1 for FAL-3809")
   api.create_collection(learning_package.id, "FAL-3809-2", title="Collection 2 for FAL-3809")
   ```
1. View the collection in the Django Admin: (`python manage.py runserver`), and ensure you can:
   * toggle the collections' "enabled" flag on and off from the list view.
   * edit the collections' title and/or description.
   * delete Collection 1 using Django Admin
1. Using the API, soft-delete, restore, and delete a collection (`python manage.py shell`):
   ```
   from openedx_learning.authoring import api
   collection = api.get_collection("FAL-3809", "FAL-3809-2")
   assert collection.enabled
   # Soft delete
   collection = api.delete_collection("FAL-3809", "FAL-3809-2")
   assert not collection.enabled
   # Restore
   collection = api.restore_collection("FAL-3809", "FAL-3809-2")
   assert collection.enabled
   # Hard delete
   collection = api.delete_collection("FAL-3809", "FAL-3809-2", hard_delete=True)
   assert not collection.id
   ```

## Deadline

ASAP
