### PR TITLE
test: add collections app to import linter config

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -46,6 +46,10 @@ layers=
     # without versioning information. These belong to a single Learning Package.
     openedx_learning.apps.authoring.contents
 
+    # The "collections" app stores arbitrary groupings of PublishableEntities.
+    # Its only dependency should be the publishing app.
+    openedx_learning.apps.authoring.collections
+
     # The lowest layer is "publishing", which holds the basic primitives needed
     # to create Learning Packages and manage the draft and publish states for
     # various types of content.


### PR DESCRIPTION
All new apps should have an entry in the .importlinter config file so that our internal dependency tree stays clean, but we don't actually document that anywhere yet.

Made https://github.com/openedx/openedx-learning/issues/230 to track work around making a "new app" checklist doc to help with this sort of thing in the future.
