### PR TITLE
Asset handling updates (config, admin)

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -1,4 +1,4 @@
 """
 Open edX Learning ("Learning Core").
 """
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -269,7 +269,15 @@ def get_component_by_uuid(uuid: UUID) -> Component:
 
 
 def get_component_version_by_uuid(uuid: UUID) -> ComponentVersion:
-    return ComponentVersion.objects.get(publishable_entity_version__uuid=uuid)
+    return (
+        ComponentVersion
+        .objects
+        .select_related(
+            "component",
+            "component__learning_package",
+        )
+        .get(publishable_entity_version__uuid=uuid)
+    )
 
 
 def component_exists_by_key(
@@ -510,7 +518,12 @@ def get_redirect_response_for_component_asset(
 
     # Check: Does the ComponentVersion exist?
     try:
-        component_version = get_component_version_by_uuid(component_version_uuid)
+        component_version = (
+            ComponentVersion
+            .objects
+            .select_related("component", "component__learning_package")
+            .get(publishable_entity_version__uuid=component_version_uuid)
+        )
     except ComponentVersion.DoesNotExist:
         # No need to add headers here, because no ComponentVersion was found.
         logger.error(f"Asset Not Found: No ComponentVersion with UUID {component_version_uuid}")

--- a/test_settings.py
+++ b/test_settings.py
@@ -69,3 +69,14 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'edx_rest_framework_extensions.paginators.DefaultPagination',
     'PAGE_SIZE': 10,
 }
+
+######################## LEARNING CORE SETTINGS ########################
+
+OPENEDX_LEARNING = {
+    'MEDIA': {
+        'BACKEND': 'django.core.files.storage.InMemoryStorage',
+        'OPTIONS': {
+            'location': MEDIA_ROOT + "_private"
+        }
+    }
+}

--- a/tests/openedx_learning/apps/authoring/components/test_api.py
+++ b/tests/openedx_learning/apps/authoring/components/test_api.py
@@ -381,7 +381,7 @@ class CreateNewVersionsTestCase(ComponentTestCase):
         components_api.create_component_version_content(
             new_version.pk,
             new_content.pk,
-            key="hello.txt",
+            key="my/path/to/hello.txt",
             learner_downloadable=False,
         )
         # re-fetch from the database to check to see if we wrote it correctly
@@ -390,7 +390,23 @@ class CreateNewVersionsTestCase(ComponentTestCase):
                                     .get(publishable_entity_version__version_num=1)
         assert (
             new_content ==
-            new_version.contents.get(componentversioncontent__key="hello.txt")
+            new_version.contents.get(componentversioncontent__key="my/path/to/hello.txt")
+        )
+
+        # Write the same content again, but to an absolute path (should auto-
+        # strip) the leading '/'s.
+        components_api.create_component_version_content(
+            new_version.pk,
+            new_content.pk,
+            key="//nested/path/hello.txt",
+            learner_downloadable=False,
+        )
+        new_version = components_api.get_component(self.problem.pk) \
+                                    .versions \
+                                    .get(publishable_entity_version__version_num=1)
+        assert (
+            new_content ==
+            new_version.contents.get(componentversioncontent__key="nested/path/hello.txt")
         )
 
     def test_multiple_versions(self):

--- a/tests/openedx_learning/apps/authoring/components/test_assets.py
+++ b/tests/openedx_learning/apps/authoring/components/test_assets.py
@@ -167,7 +167,7 @@ class AssetTestCase(TestCase):
         assert response.status_code == 200
         assert response.headers["Etag"] == self.html_asset_content.hash_digest
         assert response.headers["Content-Type"] == "text/html"
-        assert response.headers["X-Accel-Redirect"] == self.html_asset_content.file_path()
+        assert response.headers["X-Accel-Redirect"] == self.html_asset_content.path
         assert "X-Open-edX-Error" not in response.headers
 
     def test_public_asset_response(self):

--- a/tests/openedx_learning/apps/authoring/contents/test_file_storage.py
+++ b/tests/openedx_learning/apps/authoring/contents/test_file_storage.py
@@ -1,0 +1,79 @@
+"""
+Tests for file-backed Content
+"""
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+from openedx_learning.apps.authoring.contents import api as contents_api
+from openedx_learning.apps.authoring.contents.models import get_storage
+from openedx_learning.apps.authoring.publishing import api as publishing_api
+from openedx_learning.lib.test_utils import TestCase
+
+
+class ContentFileStorageTestCase(TestCase):
+    """
+    Test the storage of files backing Content.
+    """
+    def setUp(self) -> None:
+        """
+        It's actually important that we use setUp and not setUpTestData here,
+        because at least one of our tests will clear the get_storage cache,
+        meaning that subsequent tests will get a new instance of the
+        InMemoryStorage backend–and consequently wouldn't see any data loaded
+        by setUpTestData.
+
+        Recreating the test data for every test lets individual tests change the
+        storage configuration without creating side-effects for other tests.
+        """
+        super().setUp()
+        learning_package = publishing_api.create_learning_package(
+            key="ContentFileStorageTestCase-test-key",
+            title="Content File Storage Test Case Learning Package",
+        )
+        self.html_media_type = contents_api.get_or_create_media_type("text/html")
+        self.html_content = contents_api.get_or_create_file_content(
+            learning_package.id,
+            self.html_media_type.id,
+            data=b"<html>hello world!</html>",
+            created=datetime.now(tz=timezone.utc),
+        )
+
+    def test_file_path(self):
+        """
+        Test that the file path doesn't change.
+
+        If this test breaks, it means that we've changed the convention for
+        where we're storing the backing files for Content, which means we'll be
+        breaking backwards compatibility for everyone. Please be very careful if
+        you're updating this test.
+        """
+        content = self.html_content
+        assert content.path == f"content/{content.learning_package.uuid}/{content.hash_digest}"
+
+        storage_root = settings.OPENEDX_LEARNING['MEDIA']['OPTIONS']['location']
+        assert content.os_path() == f"{storage_root}/{content.path}"
+
+    def test_read(self):
+        """Make sure we can read the file data back."""
+        assert b"<html>hello world!</html>" == self.html_content.read_file().read()
+
+    @override_settings()
+    def test_misconfiguration(self):
+        """
+        Require the OPENEDX_LEARNING setting for file operations.
+
+        The main goal of this is that we don't want to store our files in the
+        default MEDIA_ROOT, because that would make them publicly accessible.
+
+        We set our OPENEDX_LEARNING value in test_settings.py. We're going to
+        delete this setting in our test and make sure we raise the correct
+        exception (The @override_settings decorator will set everything back to
+        normal after the test completes.)
+        """
+        get_storage.cache_clear()
+        del settings.OPENEDX_LEARNING
+        with self.assertRaises(ImproperlyConfigured):
+            self.html_content.read_file()


### PR DESCRIPTION
I think this should be the last of the Learning Core changes needed to get minimal asset handling into Content Libraries.

The meat of this is:

```
feat!: require OPENEDX_LEARNING setting for Content storage

WARNING: This commit will break any file-backed Content entries you
currently have. Though you will likely only have them if you've used the
very recently created add_assets_to_component command.

This commit switches us away from using the default_storage and requires
the project to set an OPENEDX_LEARNING settings dictionary with a MEDIA
key like:

OPENEDX_LEARNING = {
    'MEDIA': {
        "BACKEND": "django.core.files.storage.FileSystemStorage",
        "OPTIONS": {
            "location": "/openedx/media-private/openedx-learning",
        }
    }
}

If no such setting is present, Content operations that require file
access will raise a django.core.exceptions.ImproperlyConfigured error.

In addition to that, Content files will be stored in a "content"
subdirectory of the specified media location. This is to allow us more
flexibility as we start to use file storage for other things like the
import/export process.

We need to have a separate space for Learning Core media files because
these files should NOT be directly accessible via the browser (as the
MEDIA_ROOT is). This is because of access policies and the fact that the
filenames will not be meaningful by themselves and must be translated by
app logic. For details, please see:

* docs/decisions/0015-serving-static-assets.rst
* openedx_learning/apps/authoring/contents/models.py
* openedx_learning/apps/authoring/components/models.py

Hiding these files in a new location also required changes to the Django
admin, which are included here. This commit also adds a little extra to
the admin to make it easier to map Component assets to actual files on
disk.

This commit also adds the following helpers to the Content model:

* read_file(): return opened Django File object for the Content.
* os_path(): get the full OS path to the stored file, if available.
* path(): get the logical path for this asset relative to our configured
  OPENEDX_LEARNING['MEDIA'] storage root.

This commit also auto-strips file paths starting with '/'. Allowing
absolute paths tripped me up multiple times as I was setting up my test
data, and I don't think there's any advantage to allowing
inconsistencies (e.g. "/static/foo.png" and "static/foo.png"). We now
force the relative form ("static/foo.png").```
```

Also includes the following performance tweak:

```
perf: reduce db calls for ComponentVersion after lookup by UUID

When you fetch a single ComponentVersion, you are often going to want to
pull data related to its Component, and possibly the LearningPackage it
belongs to. This commit adds a select_related call to eliminate the
extra roundtrips for this information.
```

This will not work without the `OPENEDX_LEARNING` setting set, which will be done by default in tutor dev once https://github.com/overhangio/tutor/pull/1124 lands.

Screenshots:

![admin-content-preview](https://github.com/user-attachments/assets/eb15341c-6480-4c1c-b3ad-965b3dc89623)
![admin-component-asset](https://github.com/user-attachments/assets/b3b4be65-5f8d-43b4-8fbe-2831cf43ba95)
