### PR TITLE
fix: Update ObjectTagView and ObjectTagCountsView to accept complex objectIds

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -450,6 +450,7 @@ class ObjectTagView(
     minimal_serializer_class = ObjectTagMinimalSerializer
     permission_classes = [ObjectTagObjectPermissions]
     lookup_field = "object_id"
+    lookup_value_regex = r'[\w\.\+\-@:]+'
 
     def get_queryset(self) -> models.QuerySet:
         """
@@ -619,6 +620,7 @@ class ObjectTagCountsView(
 
     serializer_class = ObjectTagSerializer
     lookup_field = "object_id_pattern"
+    lookup_value_regex = r'[\w\.\+\-@:*,]+'
 
     def retrieve(self, request, *args, **kwargs) -> Response:
         """

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -1022,7 +1022,10 @@ class TestObjectTagViewSet(TestTagTaxonomyMixin, APITestCase):
         ("staff", "taxonomy", {"enabled": False}, ["Fungi"], status.HTTP_403_FORBIDDEN, "abc.xyz"),
         # If allow_multiple=True, multiple tags can be added, but not if it's false:
         ("user_1", "taxonomy", {"allow_multiple": True}, ["Mammalia", "Fungi"], status.HTTP_200_OK, "abc.xyz"),
-        ("user_1", "taxonomy", {"allow_multiple": False}, ["Mammalia", "Fungi"], status.HTTP_400_BAD_REQUEST, "abc.xyz"),
+        (
+            "user_1", "taxonomy", {"allow_multiple": False},
+            ["Mammalia", "Fungi"], status.HTTP_400_BAD_REQUEST, "abc.xyz"
+        ),
         # user_1s and staff can add tags using an open taxonomy
         (None, "free_text_taxonomy", {}, ["tag1"], status.HTTP_401_UNAUTHORIZED, "abc.xyz"),
         ("user_1", "free_text_taxonomy", {}, ["tag1", "tag2"], status.HTTP_200_OK, "abc"),


### PR DESCRIPTION
**Current:**
The current approach is to save the id of the content through a generic string, so that the tag can be linked to any type of content, no matter what type of ID have. For example, with this approach we can link standalone blocks and library blocks, both on Denver (v3) and Blockstore Content Libraries (v2).

**Issue:**
With complex object_id e.g; `course-v1:MIT+lt101.1+101.1` which is a acceptable format, django resolver is throwing 404

**What this PR does?**
This PR is adding a regex for `object_id` lookup field value in `ObjectTagView` and `ObjectTagCountsView` to make it accept special characters specially those which are common in openedx course creation

Before:
![image](https://github.com/user-attachments/assets/9d9717f0-444b-40fb-b077-e1a15bde00c3)

After: 
![image](https://github.com/user-attachments/assets/ed184694-092f-4ed7-b622-84f2d501ae64)
