### PR TITLE
feat: handle file content logic when creating next component version

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,4 @@ omit =
     *admin.py
     *static*
     *templates*
+    **/tests/**

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,7 @@ source =
 	openedx_tagging
 omit =
     test_settings
-    *migrations*
+    **/migrations/*
     *admin.py
     *static*
     *templates*

--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.16.2"
+__version__ = "0.16.3"

--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -147,6 +147,9 @@ def create_next_component_version(
     local path/key for a file, to ``Content.id`` or content bytes values. Using
     `None` for a value in this dict means to delete that key in the next version.
 
+    Make sure to wrap the function call on a atomic statement:
+    ``with transaction.atomic():``
+
     It is okay to mark entries for deletion that don't exist. For instance, if a
     version has ``a.txt`` and ``b.txt``, sending a ``content_to_replace`` value
     of ``{"a.txt": None, "c.txt": None}`` will remove ``a.txt`` from the next

--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -141,7 +141,7 @@ def create_next_component_version(
     A very common pattern for making a new ComponentVersion is going to be "make
     it just like the last version, except changing these one or two things".
     Before calling this, you should create any new contents via the contents
-    API, since ``content_to_replace`` needs Content IDs for the values.
+    API or send the content bytes as part of ``content_to_replace`` values.
 
     The ``content_to_replace`` dict is a mapping of strings representing the
     local path/key for a file, to ``Content.id`` or content bytes values. Using

--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -144,8 +144,8 @@ def create_next_component_version(
     API, since ``content_to_replace`` needs Content IDs for the values.
 
     The ``content_to_replace`` dict is a mapping of strings representing the
-    local path/key for a file, to ``Content.id`` values. Using a `None` for
-    a value in this dict means to delete that key in the next version.
+    local path/key for a file, to ``Content.id`` or content bytes values. Using
+    `None` for a value in this dict means to delete that key in the next version.
 
     It is okay to mark entries for deletion that don't exist. For instance, if a
     version has ``a.txt`` and ``b.txt``, sending a ``content_to_replace`` value
@@ -187,25 +187,27 @@ def create_next_component_version(
             component_id=component_pk,
         )
         # First copy the new stuff over...
-        for key, content_pk in content_to_replace.items():
+        for key, content_pk_or_bytes in content_to_replace.items():
             # If the content_pk is None, it means we want to remove the
             # content represented by our key from the next version. Otherwise,
             # we add our key->content_pk mapping to the next version.
-            if content_pk is not None:
-                if isinstance(content_pk, bytes):
-                    file_path, file_content = key, content_pk
+            if content_pk_or_bytes is not None:
+                if isinstance(content_pk_or_bytes, bytes):
+                    file_path, file_content = key, content_pk_or_bytes
                     media_type_str, _encoding = mimetypes.guess_type(file_path)
                     # We use "application/octet-stream" as a generic fallback media type, per
                     # RFC 2046: https://datatracker.ietf.org/doc/html/rfc2046
                     media_type_str = media_type_str or "application/octet-stream"
                     media_type = contents_api.get_or_create_media_type(media_type_str)
                     content = contents_api.get_or_create_file_content(
-                        component.publishable_entity.learning_package.id,
+                        component.learning_package.id,
                         media_type.id,
                         data=file_content,
                         created=created,
                     )
                     content_pk = content.pk
+                else:
+                    content_pk = content_pk_or_bytes
                 ComponentVersionContent.objects.create(
                     content_id=content_pk,
                     component_version=component_version,

--- a/openedx_learning/apps/authoring/components/management/commands/add_assets_to_component.py
+++ b/openedx_learning/apps/authoring/components/management/commands/add_assets_to_component.py
@@ -4,14 +4,12 @@ Management command to add files to a Component.
 This is mostly meant to be a debugging tool to let us to easily load some test
 asset data into the system.
 """
-import mimetypes
 import pathlib
 from datetime import datetime, timezone
 
 from django.core.management.base import BaseCommand
 
 from ....components.api import create_component_version_content
-from ....contents.api import get_or_create_file_content, get_or_create_media_type
 from ....publishing.api import get_learning_package_by_key
 from ...api import create_next_component_version, get_component_by_key
 
@@ -70,7 +68,7 @@ class Command(BaseCommand):
 
         created = datetime.now(tz=timezone.utc)
         keys_to_remove = set()
-        local_keys_to_content = {}
+        local_keys_to_raw_content = {}
 
         for file_mapping in file_mappings:
             local_key, file_path = file_mapping.split(":", 1)
@@ -80,22 +78,14 @@ class Command(BaseCommand):
                 keys_to_remove.add(local_key)
                 continue
 
-            media_type_str, _encoding = mimetypes.guess_type(file_path)
-            media_type = get_or_create_media_type(media_type_str)
-            content = get_or_create_file_content(
-                learning_package.id,
-                media_type.id,
-                data=pathlib.Path(file_path).read_bytes(),
-                created=created,
-            )
-            local_keys_to_content[local_key] = content.id
+            local_keys_to_raw_content[local_key] = pathlib.Path(file_path).read_bytes()
 
         next_version = create_next_component_version(
             component.pk,
             content_to_replace={local_key: None for local_key in keys_to_remove},
             created=created,
         )
-        for local_key, content_id in sorted(local_keys_to_content.items()):
+        for local_key, content_id in sorted(local_keys_to_raw_content.items()):
             create_component_version_content(
                 next_version.pk,
                 content_id,

--- a/tests/openedx_learning/apps/authoring/components/test_api.py
+++ b/tests/openedx_learning/apps/authoring/components/test_api.py
@@ -439,7 +439,6 @@ class CreateNewVersionsTestCase(ComponentTestCase):
         assert str(content_raw_txt.media_type) == 'application/octet-stream'
         assert content_raw_txt.read_file().read() == bytes_content
 
-
     def test_multiple_versions(self):
         hello_content = contents_api.get_or_create_text_content(
             self.learning_package.id,

--- a/tests/openedx_learning/apps/authoring/components/test_api.py
+++ b/tests/openedx_learning/apps/authoring/components/test_api.py
@@ -442,13 +442,14 @@ class CreateNewVersionsTestCase(ComponentTestCase):
             content_to_replace={
                 "hello.txt": hello_content.pk,
                 "goodbye.txt": goodbye_content.pk,
+                "raw.txt": b'raw content',
             },
             created=self.now,
         )
         assert version_1.version_num == 1
         assert version_1.title == "Problem Version 1"
         version_1_contents = list(version_1.contents.all())
-        assert len(version_1_contents) == 2
+        assert len(version_1_contents) == 3
         assert (
             hello_content ==
             version_1.contents
@@ -472,7 +473,7 @@ class CreateNewVersionsTestCase(ComponentTestCase):
             created=self.now,
         )
         assert version_2.version_num == 2
-        assert version_2.contents.count() == 3
+        assert version_2.contents.count() == 4
         assert (
             blank_content ==
             version_2.contents
@@ -503,7 +504,7 @@ class CreateNewVersionsTestCase(ComponentTestCase):
             created=self.now,
         )
         assert version_3.version_num == 3
-        assert version_3.contents.count() == 1
+        assert version_3.contents.count() == 2
         assert (
             hello_content ==
             version_3.contents


### PR DESCRIPTION
### Description

This PR updates `create_next_component_version` to handle raw bytes and content.pk logic to add assets. Closes https://github.com/openedx/openedx-learning/issues/241