### PR TITLE
feat: remove unpublished from collections [FC-0062]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.16.3"
+__version__ = "0.17.0"

--- a/openedx_learning/apps/authoring/collections/api.py
+++ b/openedx_learning/apps/authoring/collections/api.py
@@ -217,7 +217,7 @@ def remove_unpublished_from_collections(learning_package_id: int) -> None:
     all_entities = CollectionPublishableEntity.objects.filter(
         collection__learning_package__id=learning_package_id
     ).values_list('entity_id', flat=True)
-    
+
     entities_with_version = Published.objects.select_related("version").filter(
         entity_id__in=all_entities
     ).values_list('entity_id', flat=True)

--- a/openedx_learning/apps/authoring/collections/api.py
+++ b/openedx_learning/apps/authoring/collections/api.py
@@ -211,6 +211,10 @@ def remove_unpublished_from_collections(learning_package_id: int) -> None:
     """
     Removes all unpublished entities from collections for a
     given learning package.
+
+    One use case for this function is when reverting to published.
+    If a collection has unpublished entities and the learning package is reverted
+    to the published version, the unpublished entities need to be removed.
     """
     collections = get_collections(learning_package_id)
 

--- a/openedx_learning/apps/authoring/collections/api.py
+++ b/openedx_learning/apps/authoring/collections/api.py
@@ -212,9 +212,10 @@ def remove_unpublished_from_collections(learning_package_id: int) -> None:
     Removes all unpublished entities from collections for a
     given learning package.
 
-    One use case for this function is when reverting to published.
-    If a collection has unpublished entities and the learning package is reverted
-    to the published version, the unpublished entities need to be removed.
+    One use case for this function is when reverting a library to published version.
+    If a collection of a library has unpublished entities and the library is reverted
+    to the published version, the unpublished entities need to be removed
+    to reflect the published state of the library.
     """
     collections = get_collections(learning_package_id)
 

--- a/tests/openedx_learning/apps/authoring/collections/test_api.py
+++ b/tests/openedx_learning/apps/authoring/collections/test_api.py
@@ -405,6 +405,22 @@ class CollectionAddRemoveEntitiesTestCase(CollectionEntitiesTestCase):
             self.collection3.key,
         ))
 
+    def test_remove_unpublished_components(self):
+        api.remove_unpublished_from_collections(self.learning_package.id)
+
+        assert list(api.get_collection_components(
+            self.learning_package.id,
+            self.collection1.key,
+        )) == [self.published_component]
+        assert list(api.get_collection_components(
+            self.learning_package.id,
+            self.collection2.key,
+        )) == [self.published_component]
+        assert not list(api.get_collection_components(
+            self.learning_package.id,
+            self.collection3.key,
+        ))
+
 
 class UpdateCollectionTestCase(CollectionTestCase):
     """


### PR DESCRIPTION
## Description

Add `remove_unpublished_from_collections` in `api`. Removes all unpublished entities from collections for a given learning package. One use case for this function is when reverting a library to published version. If a collection of a library has unpublished entities and the library is reverted to the published version, the unpublished entities need to be removed to reflect the published state of the library

## Support information

Github issue: https://github.com/openedx/modular-learning/issues/234
Internal ticket: [FAL-3921](https://tasks.opencraft.com/browse/FAL-3921)
Used on: https://github.com/openedx/edx-platform/pull/35734

# Testing instructions

- Verify that the tests covers the new code
- Follow the testing instructions in https://github.com/openedx/edx-platform/pull/35734