### PR TITLE
fix: make database function compatible with postgresql and mysql both

### DIFF
--- a/openedx_tagging/core/tagging/models/utils.py
+++ b/openedx_tagging/core/tagging/models/utils.py
@@ -10,7 +10,7 @@ RESERVED_TAG_CHARS = [
            # e.g. lineage="Earth\tNorth America\tMexico\tMexico City"
     ' > ',  # Used in the search index and Instantsearch frontend to separate tag levels
             # e.g. tags_level3="Earth > North America > Mexico > Mexico City"
-    ';',   # Used in CSV exports to separate multiple tags from the same taxonomy…
+    ';',   # Used in CSV exports to separate multiple tags from the same taxonomy
            # e.g. languages-v1: en;es;fr
 ]
 TAGS_CSV_SEPARATOR = RESERVED_TAG_CHARS[2]


### PR DESCRIPTION
## Summary

This pull request includes updates to the `StringAgg` class in `openedx_tagging/core/tagging/models/utils.py` to enhance its functionality and compatibility with different database backends. The most important changes include adding support for PostgreSQL, MySQL, and SQLite, and implementing abstract methods from the `Combinable` class.

Enhancements to `StringAgg` class:

* Added support for PostgreSQL by using `STRING_AGG` with a specified separator and ensuring expressions are cast to `TEXT`.
* Added support for MySQL and SQLite by using `GROUP_CONCAT` with a specified separator.
* Implemented abstract methods from the `Combinable` class to allow logical operations (`AND`, `OR`, `XOR`).

Additional changes:

* Imported `db_connection` from `django.db` to check the database backend.
* Updated the `StringAgg` class to accept a `delimiter` parameter and handle the `distinct` option and output type accordingly.

This PR is subsequent of https://github.com/openedx/edx-platform/pull/35762