### PR TITLE
fix: errors during swagger api-docs generation

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"

--- a/openedx_tagging/core/tagging/rest_api/v1/serializers.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/serializers.py
@@ -157,8 +157,7 @@ class ObjectTagSerializer(ObjectTagMinimalSerializer):
     class Meta:
         model = ObjectTag
         fields = ObjectTagMinimalSerializer.Meta.fields + [
-            # The taxonomy name
-            "name",
+            "export_id",
             "taxonomy_id",
             # If the Tag or Taxonomy has been deleted, this ObjectTag shouldn't be shown to users.
             "is_deleted",

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -799,6 +799,9 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         context['request'] = self.request
         serializer = self.serializer_class(self, context=context)
 
+        if getattr(self, 'swagger_fake_view', False):
+            # queryset just for schema generation metadata
+            return context
         # Instead of checking permissions for each TagData instance, we just check them once for the whole taxonomy
         # (since that's currently how our rules work). This might change if Tag-specific permissions are needed.
         taxonomy = self.get_taxonomy()
@@ -814,6 +817,9 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         """
         Builds and returns the queryset to be paginated.
         """
+        if getattr(self, 'swagger_fake_view', False):
+            # queryset just for schema generation metadata
+            return Taxonomy.objects.none()  # type: ignore[return-value]
         taxonomy = self.get_taxonomy()
         parent_tag_value = self.request.query_params.get("parent_tag", None)
         include_counts = "include_counts" in self.request.query_params

--- a/openedx_tagging/core/tagging/rest_api/v1/views.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/views.py
@@ -782,8 +782,8 @@ class TaxonomyTagsView(ListAPIView, RetrieveUpdateDestroyAPIView):
         The current taxonomy is cached in the view.
         """
         if not self._taxonomy:
-            taxonomy_id = int(self.kwargs["pk"])
-            taxonomy = get_taxonomy(taxonomy_id)
+            taxonomy_id = self.kwargs.get("pk")
+            taxonomy = get_taxonomy(int(taxonomy_id)) if taxonomy_id else None
             if not taxonomy:
                 raise Http404("Taxonomy not found")
             self.check_object_permissions(self.request, taxonomy)


### PR DESCRIPTION
This PR fixes two errors seen during the automatic Swagger API docs generation.

Part of: https://github.com/openedx/openedx-learning/issues/272
Private-ref: [FAL-4039](https://tasks.opencraft.com/browse/FAL-4039)

## Testing instructions

1. Install this branch in your edx-platform devstack
2. Visit the Studio API docs page, e.g http://local.openedx.io:8001/api-docs/
    Note that the page renders now without error.