### PR TITLE
feat: adds unmark_copied_tags method to tagging API [FC-0076]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.18.2"
+__version__ = "0.18.3"

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -516,3 +516,10 @@ def copy_tags(source_object_id: str, dest_object_id: str):
                 defaults={"is_copied": True},
                 # Note: _value and _export_id are set automatically
             )
+
+
+def unmark_copied_tags(object_id: str) -> None:
+    """
+    Update copied object tags on the given object to mark them as "not copied".
+    """
+    ObjectTag.objects.filter(object_id=object_id).update(is_copied=False)

--- a/tests/openedx_tagging/core/fixtures/tagging.yaml
+++ b/tests/openedx_tagging/core/fixtures/tagging.yaml
@@ -247,7 +247,7 @@
     name: System defined taxonomy
     description: Generic System defined taxonomy
     enabled: true
-    allow_multiple: false
+    allow_multiple: true
     allow_free_text: false
     export_id: system_defined_taxonomy
     _taxonomy_class: openedx_tagging.core.tagging.models.system_defined.SystemDefinedTaxonomy

--- a/tests/openedx_tagging/core/tagging/test_api.py
+++ b/tests/openedx_tagging/core/tagging/test_api.py
@@ -1046,3 +1046,27 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
             assert object_tag.taxonomy == expected_tags[index]["taxonomy"]
             assert object_tag.object_id == obj2
             assert object_tag.is_copied == expected_tags[index]["copied"]
+
+    def test_unmark_copied_tags(self) -> None:
+        obj1 = "object_id1"
+        obj2 = "object_id2"
+
+        # Put 2 tags on obj1
+        tagging_api.tag_object(object_id=obj1, taxonomy=self.language_taxonomy, tags=["English"])
+        tagging_api.tag_object(object_id=obj1, taxonomy=self.system_taxonomy, tags=["System Tag 1"])
+
+        # Copy tags from obj1 to obj2
+        tagging_api.copy_tags(obj1, obj2)
+
+        # Update obj2's tags to include one non-copied tag
+        tagging_api.tag_object(object_id=obj2, taxonomy=self.system_taxonomy, tags=["System Tag 1", "System Tag 2"])
+
+        tags = tagging_api.get_object_tags(obj2)
+        assert tags.filter(is_copied=False).count() == 1
+        assert tags.filter(is_copied=True).count() == 2
+
+        tagging_api.unmark_copied_tags(obj2)
+
+        tags = tagging_api.get_object_tags(obj2)
+        assert tags.filter(is_copied=False).count() == 3
+        assert tags.filter(is_copied=True).count() == 0


### PR DESCRIPTION
### Description

Adds a `unmark_copied_tags` method to the tagging API which unsets the `is_copied` flag on the given object's tags.

### Supporting information

Part of: https://github.com/openedx/modular-learning/issues/244
Private-ref: [FAL-4008](https://tasks.opencraft.com/browse/FAL-4008)

### Testing instructions

See edx-platform PR.