### PR TITLE
test: verify correct typing of mixins

### DIFF
--- a/tests/openedx_learning/apps/authoring/components/test_models.py
+++ b/tests/openedx_learning/apps/authoring/components/test_models.py
@@ -2,6 +2,7 @@
 Tests related to the Component models
 """
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, assert_type
 
 from freezegun import freeze_time
 
@@ -10,7 +11,7 @@ from openedx_learning.apps.authoring.components.api import (
     get_component,
     get_or_create_component_type,
 )
-from openedx_learning.apps.authoring.components.models import ComponentType
+from openedx_learning.apps.authoring.components.models import Component, ComponentType, ComponentVersion
 from openedx_learning.apps.authoring.publishing.api import (
     LearningPackage,
     create_learning_package,
@@ -18,6 +19,15 @@ from openedx_learning.apps.authoring.publishing.api import (
     publish_all_drafts,
 )
 from openedx_learning.lib.test_utils import TestCase
+
+if TYPE_CHECKING:
+    # Test that our mixins on Component.objects and PublishableEntityVersionMixin etc. haven't broken manager typing
+    assert_type(Component.objects.create(), Component)
+    assert_type(Component.objects.get(), Component)
+    assert_type(Component.with_publishing_relations.create(), Component)
+    assert_type(Component.with_publishing_relations.get(), Component)
+    assert_type(ComponentVersion.objects.create(), ComponentVersion)
+    assert_type(ComponentVersion.objects.get(), ComponentVersion)
 
 
 class TestModelVersioningQueries(TestCase):

--- a/tests/openedx_learning/apps/authoring/publishing/test_models.py
+++ b/tests/openedx_learning/apps/authoring/publishing/test_models.py
@@ -1,0 +1,21 @@
+"""
+Tests related to the Publishing model mixins
+"""
+from typing import TYPE_CHECKING, assert_type
+
+from openedx_learning.apps.authoring.publishing.models import PublishableEntityMixin, PublishableEntityVersionMixin
+from openedx_learning.lib.managers import WithRelationsManager
+
+if TYPE_CHECKING:
+    # Test that our mixins provide the right typing for 'objects'
+    class FooEntity(PublishableEntityMixin):
+        pass
+
+    assert_type(FooEntity.objects.create(), FooEntity)
+    assert_type(FooEntity.objects, WithRelationsManager[FooEntity])
+
+    class FooEntityVersion(PublishableEntityVersionMixin):
+        pass
+
+    assert_type(FooEntityVersion.objects.create(), FooEntityVersion)
+    assert_type(FooEntityVersion.objects, WithRelationsManager[FooEntityVersion])


### PR DESCRIPTION
This PR makes some simplifications to `PublishableEntityMixin` and `PublishableEntityVersionMixin` so that their subclasses like `ComponentVersion` automatically get the correct type on their `objects` class property, and don't have to override it to satisfy mypy. This will slightly simplify the code as we get more publishable entities in the near future (e.g. components and units).

I also got rid of the custom `PublishableEntityMixinManager` and `PublishableEntityVersionMixinManager` classes, replacing them with the reusable `WithRelationsManager` that does the same thing and which now supports generic typing properly.

New type-only tests are added to assert that the typing of the manager (`objects`) and its returned instances are correct.