### PR TITLE
Minor typing improvements [FC-0083]

### DIFF
--- a/openedx_learning/apps/authoring/components/api.py
+++ b/openedx_learning/apps/authoring/components/api.py
@@ -468,7 +468,7 @@ def _get_component_version_info_headers(component_version: ComponentVersion) -> 
         "X-Open-edX-Component-Uuid": component.uuid,
         # Component Version
         "X-Open-edX-Component-Version-Uuid": component_version.uuid,
-        "X-Open-edX-Component-Version-Num": component_version.version_num,
+        "X-Open-edX-Component-Version-Num": str(component_version.version_num),
         # Learning Package
         "X-Open-edX-Learning-Package-Key": learning_package.key,
         "X-Open-edX-Learning-Package-Uuid": learning_package.uuid,

--- a/openedx_learning/apps/authoring/components/apps.py
+++ b/openedx_learning/apps/authoring/components/apps.py
@@ -14,7 +14,7 @@ class ComponentsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     label = "oel_components"
 
-    def ready(self):
+    def ready(self) -> None:
         """
         Register Component and ComponentVersion.
         """

--- a/openedx_learning/apps/authoring/components/models.py
+++ b/openedx_learning/apps/authoring/components/models.py
@@ -72,7 +72,7 @@ class ComponentType(models.Model):
         ),
     ]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.namespace}:{self.name}"
 
 
@@ -190,7 +190,7 @@ class Component(PublishableEntityMixin):  # type: ignore[django-manager-missing]
         verbose_name = "Component"
         verbose_name_plural = "Components"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.component_type.namespace}:{self.component_type.name}:{self.local_key}"
 
 

--- a/openedx_learning/apps/authoring/contents/models.py
+++ b/openedx_learning/apps/authoring/contents/models.py
@@ -121,7 +121,7 @@ class MediaType(models.Model):
             ),
         ]
 
-    def __str__(self):
+    def __str__(self) -> str:
         base = f"{self.type}/{self.sub_type}"
         if self.suffix:
             return f"{base}+{self.suffix}"

--- a/openedx_learning/apps/authoring/publishing/model_mixins.py
+++ b/openedx_learning/apps/authoring/publishing/model_mixins.py
@@ -3,6 +3,7 @@ Helper mixin classes for content apps that want to use the publishing app.
 """
 from __future__ import annotations
 
+from datetime import datetime
 from functools import cached_property
 
 from django.core.exceptions import ImproperlyConfigured
@@ -49,15 +50,15 @@ class PublishableEntityMixin(models.Model):
         return self.VersioningHelper(self)
 
     @property
-    def uuid(self):
+    def uuid(self) -> str:
         return self.publishable_entity.uuid
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self.publishable_entity.key
 
     @property
-    def created(self):
+    def created(self) -> datetime:
         return self.publishable_entity.created
 
     @property
@@ -311,19 +312,19 @@ class PublishableEntityVersionMixin(models.Model):
     )
 
     @property
-    def uuid(self):
+    def uuid(self) -> str:
         return self.publishable_entity_version.uuid
 
     @property
-    def title(self):
+    def title(self) -> str:
         return self.publishable_entity_version.title
 
     @property
-    def created(self):
+    def created(self) -> datetime:
         return self.publishable_entity_version.created
 
     @property
-    def version_num(self):
+    def version_num(self) -> int:
         return self.publishable_entity_version.version_num
 
     class Meta:

--- a/openedx_learning/apps/authoring/publishing/models.py
+++ b/openedx_learning/apps/authoring/publishing/models.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 
-class LearningPackage(models.Model):  # type: ignore[django-manager-missing]
+class LearningPackage(models.Model):
     """
     Top level container for a grouping of authored content.
 

--- a/openedx_learning/contrib/media_server/apps.py
+++ b/openedx_learning/contrib/media_server/apps.py
@@ -15,7 +15,7 @@ class MediaServerConfig(AppConfig):
     verbose_name = "Learning Core: Media Server"
     default_auto_field = "django.db.models.BigAutoField"
 
-    def ready(self):
+    def ready(self) -> None:
         if not settings.DEBUG:
             # Until we get proper security and support for running this app
             # under a separate domain, just don't allow it to be run in

--- a/openedx_learning/lib/validators.py
+++ b/openedx_learning/lib/validators.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 
-def validate_utc_datetime(dt: datetime):
+def validate_utc_datetime(dt: datetime) -> None:
     if dt.tzinfo != timezone.utc:
         raise ValidationError(
             _("The timezone for %(datetime)s is not UTC."),

--- a/openedx_tagging/core/tagging/api.py
+++ b/openedx_tagging/core/tagging/api.py
@@ -191,9 +191,9 @@ def get_object_tags(
     )
     if not include_deleted:
         # Exclude if the whole taxonomy was deleted
-        base_qs = base_qs.exclude(taxonomy_id=None)  # type: ignore
+        base_qs = base_qs.exclude(taxonomy=None)
         # Exclude if just the tag is deleted
-        base_qs = base_qs.exclude(tag_id=None, taxonomy__allow_free_text=False)  # type: ignore
+        base_qs = base_qs.exclude(tag=None, taxonomy__allow_free_text=False)
     tags = (
         base_qs
         # Preload related objects, including data for the "get_lineage" method on ObjectTag/Tag:

--- a/openedx_tagging/core/tagging/rest_api/v1/permissions.py
+++ b/openedx_tagging/core/tagging/rest_api/v1/permissions.py
@@ -1,7 +1,7 @@
 """
 Tagging permissions
 """
-import rules  # type: ignore[import]
+import rules
 from rest_framework.permissions import DjangoObjectPermissions
 
 from ...models import Tag, Taxonomy

--- a/openedx_tagging/core/tagging/rules.py
+++ b/openedx_tagging/core/tagging/rules.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 from typing import Callable, Union
 
 import django.contrib.auth.models
-# typing support in rules depends on https://github.com/dfunckt/django-rules/pull/177
-import rules  # type: ignore[import]
+import rules
 from attrs import define
 
 from .models import Tag, Taxonomy

--- a/tests/openedx_learning/apps/authoring/collections/test_api.py
+++ b/tests/openedx_learning/apps/authoring/collections/test_api.py
@@ -4,6 +4,7 @@ Basic tests of the Collections API.
 from datetime import datetime, timezone
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User as UserType  # pylint: disable=imported-auth-user
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from freezegun import freeze_time
 
@@ -213,7 +214,7 @@ class CollectionEntitiesTestCase(CollectionsTestCase):
     """
     published_component: Component
     draft_component: Component
-    user: User  # type: ignore [valid-type]
+    user: UserType
     html_type: ComponentType
     problem_type: ComponentType
 

--- a/tests/openedx_learning/apps/authoring/components/test_api.py
+++ b/tests/openedx_learning/apps/authoring/components/test_api.py
@@ -4,6 +4,7 @@ Basic tests of the Components API.
 from datetime import datetime, timezone
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import User as UserType  # pylint: disable=imported-auth-user
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from freezegun import freeze_time
 
@@ -541,7 +542,7 @@ class SetCollectionsTestCase(ComponentTestCase):
     collection2: Collection
     collection3: Collection
     published_problem: Component
-    user: User  # type: ignore [valid-type]
+    user: UserType
 
     @classmethod
     def setUpTestData(cls) -> None:

--- a/tests/openedx_tagging/core/tagging/test_views.py
+++ b/tests/openedx_tagging/core/tagging/test_views.py
@@ -7,8 +7,7 @@ import json
 from urllib.parse import parse_qs, quote_plus, urlparse
 
 import ddt  # type: ignore[import]
-# typing support in rules depends on https://github.com/dfunckt/django-rules/pull/177
-import rules  # type: ignore[import]
+import rules
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status


### PR DESCRIPTION
Added type annotations so that mypy checks more code. If a function doesn't have any type annotations at all, mypy will ignore it completely.

Django-rules now has types, so we don't need `# type: ignore[import]` on it.


Private ref: part of FAL-4051