### PR TITLE
feat: api for updating children in container [FC-0083]

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.19.1"
+__version__ = "0.19.2"

--- a/openedx_learning/apps/authoring/publishing/models/entity_list.py
+++ b/openedx_learning/apps/authoring/publishing/models/entity_list.py
@@ -60,6 +60,7 @@ class EntityListRow(models.Model):
     )
 
     class Meta:
+        ordering = ["order_num"]
         constraints = [
             # If (entity_list, order_num) is not unique, it likely indicates a race condition - so force uniqueness.
             models.UniqueConstraint(

--- a/openedx_learning/apps/authoring/units/api.py
+++ b/openedx_learning/apps/authoring/units/api.py
@@ -130,6 +130,7 @@ def create_next_unit_version(
     components: list[Component | ComponentVersion] | None = None,
     created: datetime,
     created_by: int | None = None,
+    entities_action: publishing_api.ChildrenEntitiesAction = publishing_api.ChildrenEntitiesAction.REPLACE,
 ) -> UnitVersion:
     """
     [ 🛑 UNSTABLE ] Create the next unit version.
@@ -151,6 +152,7 @@ def create_next_unit_version(
         created=created,
         created_by=created_by,
         container_version_cls=UnitVersion,
+        entities_action=entities_action,
     )
     return unit_version
 


### PR DESCRIPTION
**Description:**

Updates `create_next_container_version` api to handle addition or removal of children entities.

**Related to:** https://github.com/openedx/frontend-app-authoring/issues/1706 and https://github.com/openedx/frontend-app-authoring/issues/1705

`Private-ref`: https://tasks.opencraft.com/browse/FAL-4109

**Test instructions:**

* Read code
* Verify that tests are passing
