### PR TITLE
test: configure pytest for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,14 @@ requirements/private.txt
 # database file
 dev.db*
 
-.vscode
+# virtualenv
 venv/
+
+### Visual Studio Code ###
+# Generally ignore VS Code configuration, except... 
+.vscode/*
+# included for test settings, so VS Code's Testing bar works out of the box
+!.vscode/settings.json
 
 # Media files (for uploads)
 media/

--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,9 @@ venv/
 ### Visual Studio Code ###
 # Generally ignore VS Code configuration, except... 
 .vscode/*
-# included for test settings, so VS Code's Testing bar works out of the box
-!.vscode/settings.json
+# Example settings to let people quickly get up to speed with testing.
+!.vscode/launch.json.example
+!.vscode/settings.json.example
 
 # Media files (for uploads)
 media/

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -15,7 +15,10 @@
 
             // This is needed because pytest-cov is incompatible with using the
             // debugger. See https://code.visualstudio.com/docs/python/testing#_pytest-configuration-settings
-            "env": {"PYTEST_ADDOPTS": "--no-cov"}
+            "env": {"PYTEST_ADDOPTS": "--no-cov"},
+
+            // Adds some magic for Django templates.
+            "django": true
           }
     ]
 }

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": false,
+
+            // This is needed because pytest-cov is incompatible with using the
+            // debugger. See https://code.visualstudio.com/docs/python/testing#_pytest-configuration-settings
+            "env": {"PYTEST_ADDOPTS": "--no-cov"}
+          }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.testing.pytestArgs": [
-        "--ds=test_settings",
-    ],
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        "--ds=test_settings",
+    ],
+}

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,0 +1,14 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [
+        // We have to override this here instead of in pytest.ini because tutor
+        // sets the DJANGO_SETTINGS_MODULE env variable in our container to be
+        // the one for LMS or Studio, and that takes precedence over any value
+        // set in pytest.ini. The only thing that takes higher precedence than
+        // the env variable is the explicit command line parameter:
+        //
+        // https://pytest-django.readthedocs.io/en/stable/configuring_django.html#order-of-choosing-settings
+        "--ds=test_settings"
+    ],
+}

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,15 @@ Every time you develop something in this repo
 
   # Open a PR and ask for review.
 
+Configuring Visual Studio Code
+------------------------------
+
+If you are using VS Code as your editor, you can enable the Testing bar by copying from the example configuration provided in the ``.vscode`` directory::
+
+    cd .vscode/
+    cp launch.json.example launch.json
+    cp settings.json.example settings.json
+
 License
 -------
 


### PR DESCRIPTION
Add example VS Code configuration to automatically detect, run, and debug tests using VS Code's Testing bar. Developers will still need to copy these example files into their own settings in order to make use of them. This was done to avoid potential issues where developer-specific configuration could cause problems for other developers.

Some example screenshots:

## Test Browsing/Running

![Screenshot 2025-03-25 130542](https://github.com/user-attachments/assets/6ea31931-1d6c-497f-9bac-a4459cdacb17)
![Screenshot 2025-03-25 130609](https://github.com/user-attachments/assets/37d64bbf-0481-43c0-b82d-7b64cd7b52a9)

## Debugger

![Screenshot 2025-03-25 131637](https://github.com/user-attachments/assets/5f957525-f6a4-4ab3-83be-7870ec2a62c8)

## Code Coverage

![Screenshot 2025-03-25 135751](https://github.com/user-attachments/assets/92cbde09-976e-4a15-bf4a-67a83e77f1d6)
![Screenshot 2025-03-25 131011](https://github.com/user-attachments/assets/a25d0c3d-2e56-4746-a7f9-f95d7c8ff317)
