### PR TITLE
style: Delete duplicated code in units, subsections and sections APIs

### DIFF
--- a/openedx_learning/apps/authoring/sections/api.py
+++ b/openedx_learning/apps/authoring/sections/api.py
@@ -24,7 +24,6 @@ __all__ = [
     "get_latest_section_version",
     "SectionListEntry",
     "get_subsections_in_section",
-    "get_subsections_in_section",
     "get_subsections_in_published_section_as_of",
 ]
 

--- a/openedx_learning/apps/authoring/subsections/api.py
+++ b/openedx_learning/apps/authoring/subsections/api.py
@@ -24,7 +24,6 @@ __all__ = [
     "get_latest_subsection_version",
     "SubsectionListEntry",
     "get_units_in_subsection",
-    "get_units_in_subsection",
     "get_units_in_published_subsection_as_of",
 ]
 

--- a/openedx_learning/apps/authoring/units/api.py
+++ b/openedx_learning/apps/authoring/units/api.py
@@ -24,7 +24,6 @@ __all__ = [
     "get_latest_unit_version",
     "UnitListEntry",
     "get_components_in_unit",
-    "get_components_in_unit",
     "get_components_in_published_unit_as_of",
 ]
 


### PR DESCRIPTION
## Description

* Remove duplicated `get_subsections_in_section` in `__all__`
* Remove duplicated `get_units_in_subsection` in `__all__`
* Remove duplicated `get_components_in_unit` in `__all__`

This change does not affect functionality, it is just a cleanup in the code.