### PR TITLE
refactor: rename register_content_models to register_publishable_models

### DIFF
--- a/openedx_learning/apps/authoring/components/apps.py
+++ b/openedx_learning/apps/authoring/components/apps.py
@@ -18,7 +18,7 @@ class ComponentsConfig(AppConfig):
         """
         Register Component and ComponentVersion.
         """
-        from ..publishing.api import register_content_models  # pylint: disable=import-outside-toplevel
+        from ..publishing.api import register_publishable_models  # pylint: disable=import-outside-toplevel
         from .models import Component, ComponentVersion  # pylint: disable=import-outside-toplevel
 
-        register_content_models(Component, ComponentVersion)
+        register_publishable_models(Component, ComponentVersion)

--- a/openedx_learning/apps/authoring/publishing/api.py
+++ b/openedx_learning/apps/authoring/publishing/api.py
@@ -69,7 +69,7 @@ __all__ = [
     "set_draft_version",
     "soft_delete_draft",
     "reset_drafts_to_published",
-    "register_content_models",
+    "register_publishable_models",
     "filter_publishable_entities",
     # 🛑 UNSTABLE: All APIs related to containers are unstable until we've figured
     #              out our approach to dynamic content (randomized, A/B tests, etc.)
@@ -789,7 +789,7 @@ def reset_drafts_to_published(
             set_draft_version(draft, published_version_id)
 
 
-def register_content_models(
+def register_publishable_models(
     content_model_cls: type[PublishableEntityMixin],
     content_version_model_cls: type[PublishableEntityVersionMixin],
 ) -> PublishableContentModelRegistry:
@@ -805,10 +805,10 @@ def register_content_models(
     method. For example, in the components app, this looks like:
 
         def ready(self):
-            from ..publishing.api import register_content_models
+            from ..publishing.api import register_publishable_models
             from .models import Component, ComponentVersion
 
-            register_content_models(Component, ComponentVersion)
+            register_publishable_models(Component, ComponentVersion)
 
     There may be a more clever way to introspect this information from the model
     metadata, but this is simple and explicit.

--- a/openedx_learning/apps/authoring/publishing/apps.py
+++ b/openedx_learning/apps/authoring/publishing/apps.py
@@ -19,7 +19,7 @@ class PublishingConfig(AppConfig):
         """
         Register Container and ContainerVersion.
         """
-        from .api import register_content_models  # pylint: disable=import-outside-toplevel
+        from .api import register_publishable_models  # pylint: disable=import-outside-toplevel
         from .models import Container, ContainerVersion  # pylint: disable=import-outside-toplevel
 
-        register_content_models(Container, ContainerVersion)
+        register_publishable_models(Container, ContainerVersion)

--- a/openedx_learning/apps/authoring/publishing/models/publishable_entity.py
+++ b/openedx_learning/apps/authoring/publishing/models/publishable_entity.py
@@ -272,7 +272,7 @@ class PublishableEntityMixin(models.Model):
     Please see docstring for PublishableEntity for more details.
 
     If you use this class, you *MUST* also use PublishableEntityVersionMixin and
-    the publishing app's api.register_content_models (see its docstring for
+    the publishing app's api.register_publishable_models (see its docstring for
     details).
     """
     # select these related entities by default for all queries
@@ -551,7 +551,7 @@ class PublishableEntityVersionMixin(models.Model):
     Please see docstring for PublishableEntityVersion for more details.
 
     If you use this class, you *MUST* also use PublishableEntityMixin and the
-    publishing app's api.register_content_models (see its docstring for
+    publishing app's api.register_publishable_models (see its docstring for
     details).
     """
 
@@ -609,7 +609,7 @@ class PublishableContentModelRegistry:
         Register what content model maps to what content version model.
 
         If you want to call this from another app, please use the
-        ``register_content_models`` function in this app's ``api`` module
+        ``register_publishable_models`` function in this app's ``api`` module
         instead.
         """
         if not issubclass(content_model_cls, PublishableEntityMixin):

--- a/openedx_learning/apps/authoring/sections/apps.py
+++ b/openedx_learning/apps/authoring/sections/apps.py
@@ -19,7 +19,7 @@ class SectionsConfig(AppConfig):
         """
         Register Section and SectionVersion.
         """
-        from ..publishing.api import register_content_models  # pylint: disable=import-outside-toplevel
+        from ..publishing.api import register_publishable_models  # pylint: disable=import-outside-toplevel
         from .models import Section, SectionVersion  # pylint: disable=import-outside-toplevel
 
-        register_content_models(Section, SectionVersion)
+        register_publishable_models(Section, SectionVersion)

--- a/openedx_learning/apps/authoring/subsections/apps.py
+++ b/openedx_learning/apps/authoring/subsections/apps.py
@@ -19,7 +19,7 @@ class SubsectionsConfig(AppConfig):
         """
         Register Subsection and SubsectionVersion.
         """
-        from ..publishing.api import register_content_models  # pylint: disable=import-outside-toplevel
+        from ..publishing.api import register_publishable_models  # pylint: disable=import-outside-toplevel
         from .models import Subsection, SubsectionVersion  # pylint: disable=import-outside-toplevel
 
-        register_content_models(Subsection, SubsectionVersion)
+        register_publishable_models(Subsection, SubsectionVersion)

--- a/openedx_learning/apps/authoring/units/apps.py
+++ b/openedx_learning/apps/authoring/units/apps.py
@@ -19,7 +19,7 @@ class UnitsConfig(AppConfig):
         """
         Register Unit and UnitVersion.
         """
-        from ..publishing.api import register_content_models  # pylint: disable=import-outside-toplevel
+        from ..publishing.api import register_publishable_models  # pylint: disable=import-outside-toplevel
         from .models import Unit, UnitVersion  # pylint: disable=import-outside-toplevel
 
-        register_content_models(Unit, UnitVersion)
+        register_publishable_models(Unit, UnitVersion)


### PR DESCRIPTION
### Summary

This PR renames the function `register_content_models` to `register_publishable_models` to improve clarity and better reflect its purpose.

### Context

The original name `register_content_models` was ambiguous and didn’t clearly convey the function’s responsibility. Since the function specifically registers models intended to be published (e.g., in learning sequences or metadata definitions), the new name `register_publishable_models` is more accurate and aligned with its role.

### What’s Changed

- ✅ Renamed `register_content_models` to `register_publishable_models` in both implementation and usage.
- 🔄 Updated all relevant references and imports.

### Testing Instructions

- Run the test suite to ensure all references to the renamed function are working correctly.
- Verify that no functional behavior has changed—this is a non-functional rename for clarity only.

### Review Notes

- No logic has been altered—only a renaming refactor for clarity and maintainability.
- Please confirm naming consistency and suggest alternatives if the new name could be improved further.
