### PR TITLE
feat: add collection serialization to lp_dump

### DIFF
--- a/openedx_learning/apps/authoring/backup_restore/toml.py
+++ b/openedx_learning/apps/authoring/backup_restore/toml.py
@@ -168,32 +168,29 @@ def toml_collection(collection: Collection) -> str:
     The resulting content looks like:
         [collection]
         title = "Collection 1"
+        key = "COL1"
         description = "Description of Collection 1"
-        created = 2025-09-03T17:50:59.565939Z
-
-        # ### Entities
-
-        [[entity]]
-        uuid = "f8ea9bae-b4ed-4a84-ab4f-2b9850b59cd6"
-        can_stand_alone = true
-        key = "xblock.v1:problem:my_published_example"
+        created = 2025-09-03T22:28:53.839362Z
+        entities = [
+            "xblock.v1:problem:my_published_example",
+            "xblock.v1:html:my_draft_example",
+        ]
     """
     doc = tomlkit.document()
 
+    entity_keys = collection.entities.values_list("key", flat=True)
+    entities_array = tomlkit.array()
+    for entity_key in entity_keys:
+        entities_array.append(entity_key)
+    entities_array.multiline(True)
+
     collection_table = tomlkit.table()
     collection_table.add("title", collection.title)
+    collection_table.add("key", collection.key)
     collection_table.add("description", collection.description)
     collection_table.add("created", collection.created)
+    collection_table.add("entities", entities_array)
 
     doc.add("collection", collection_table)
-    doc.add(tomlkit.nl())
-    doc.add(tomlkit.comment("### Entities"))
-
-    # Entity serialization
-    for entity in collection.entities.all():
-        entities_array = tomlkit.aot()
-        entity_table = _get_toml_publishable_entity_table(entity, include_versions=False)
-        entities_array.append(entity_table)
-        doc.add("entity", entities_array)
 
     return tomlkit.dumps(doc)

--- a/openedx_learning/apps/authoring/backup_restore/toml.py
+++ b/openedx_learning/apps/authoring/backup_restore/toml.py
@@ -85,7 +85,7 @@ def _get_toml_publishable_entity_table(
     return entity_table
 
 
-def toml_publishable_entity(entity: PublishableEntity) -> str:
+def toml_publishable_entity(entity: PublishableEntity, versions_to_write: list[PublishableEntityVersion]) -> str:
     """
     Create a TOML representation of a publishable entity and its versions.
 
@@ -120,7 +120,7 @@ def toml_publishable_entity(entity: PublishableEntity) -> str:
     doc.add(tomlkit.nl())
     doc.add(tomlkit.comment("### Versions"))
 
-    for entity_version in entity.versions.all():
+    for entity_version in versions_to_write:
         version = tomlkit.aot()
         version_table = toml_publishable_entity_version(entity_version)
         version.append(version_table)

--- a/openedx_learning/apps/authoring/backup_restore/toml.py
+++ b/openedx_learning/apps/authoring/backup_restore/toml.py
@@ -6,13 +6,25 @@ from datetime import datetime
 
 import tomlkit
 
+from openedx_learning.apps.authoring.collections.models import Collection
 from openedx_learning.apps.authoring.publishing import api as publishing_api
 from openedx_learning.apps.authoring.publishing.models import PublishableEntity, PublishableEntityVersion
 from openedx_learning.apps.authoring.publishing.models.learning_package import LearningPackage
 
 
 def toml_learning_package(learning_package: LearningPackage) -> str:
-    """Create a TOML representation of the learning package."""
+    """
+    Create a TOML representation of the learning package.
+    The resulting content looks like:
+        # Datetime of the export: 2025-09-03 12:50:59.573253
+
+        [learning_package]
+        title = "Components Test Case Learning Package"
+        key = "ComponentTestCase-test-key"
+        description = "This is a test learning package for components."
+        created = 2025-09-03T17:50:59.536190Z
+        updated = 2025-09-03T17:50:59.536190Z
+    """
     doc = tomlkit.document()
     doc.add(tomlkit.comment(f"Datetime of the export: {datetime.now()}"))
     section = tomlkit.table()
@@ -25,16 +37,34 @@ def toml_learning_package(learning_package: LearningPackage) -> str:
     return tomlkit.dumps(doc)
 
 
-def toml_publishable_entity(entity: PublishableEntity) -> str:
-    """Create a TOML representation of a publishable entity."""
+def _get_toml_publishable_entity_table(
+        entity: PublishableEntity,
+        include_versions: bool = True) -> tomlkit.items.Table:
+    """
+    Create a TOML representation of a publishable entity.
+    The resulting content looks like:
+        [entity]
+        uuid = "f8ea9bae-b4ed-4a84-ab4f-2b9850b59cd6"
+        can_stand_alone = true
+        key = "xblock.v1:problem:my_published_example"
 
-    current_draft_version = publishing_api.get_draft_version(entity)
-    current_published_version = publishing_api.get_published_version(entity)
+        [entity.draft]
+        version_num = 2
 
-    doc = tomlkit.document()
+        [entity.published]
+        version_num = 1
+    """
     entity_table = tomlkit.table()
     entity_table.add("uuid", str(entity.uuid))
     entity_table.add("can_stand_alone", entity.can_stand_alone)
+    # Add key since the toml filename doesn't show the real key
+    entity_table.add("key", entity.key)
+
+    if not include_versions:
+        return entity_table
+
+    current_draft_version = publishing_api.get_draft_version(entity)
+    current_published_version = publishing_api.get_published_version(entity)
 
     if current_draft_version:
         draft_table = tomlkit.table()
@@ -47,7 +77,39 @@ def toml_publishable_entity(entity: PublishableEntity) -> str:
     else:
         published_table.add(tomlkit.comment("unpublished: no published_version_num"))
     entity_table.add("published", published_table)
+    return entity_table
 
+
+def toml_publishable_entity(entity: PublishableEntity) -> str:
+    """
+    Create a TOML representation of a publishable entity and its versions.
+    The resulting content looks like:
+        [entity]
+        uuid = "f8ea9bae-b4ed-4a84-ab4f-2b9850b59cd6"
+        can_stand_alone = true
+        key = "xblock.v1:problem:my_published_example"
+
+        [entity.draft]
+        version_num = 2
+
+        [entity.published]
+        version_num = 1
+
+        # ### Versions
+
+        [[version]]
+        title = "My published problem"
+        uuid = "2e07511f-daa7-428a-9032-17fe12a77d06"
+        version_num = 1
+
+        [version.container]
+        children = []
+
+        [version.container.unit]
+        graded = true
+    """
+    entity_table = _get_toml_publishable_entity_table(entity)
+    doc = tomlkit.document()
     doc.add("entity", entity_table)
     doc.add(tomlkit.nl())
     doc.add(tomlkit.comment("### Versions"))
@@ -62,7 +124,20 @@ def toml_publishable_entity(entity: PublishableEntity) -> str:
 
 
 def toml_publishable_entity_version(version: PublishableEntityVersion) -> tomlkit.items.Table:
-    """Create a TOML representation of a publishable entity version."""
+    """
+    Create a TOML representation of a publishable entity version.
+    The resulting content looks like:
+        [[version]]
+        title = "My published problem"
+        uuid = "2e07511f-daa7-428a-9032-17fe12a77d06"
+        version_num = 1
+
+        [version.container]
+        children = []
+
+        [version.container.unit]
+        graded = true
+    """
     version_table = tomlkit.table()
     version_table.add("title", version.title)
     version_table.add("uuid", str(version.uuid))
@@ -74,3 +149,38 @@ def toml_publishable_entity_version(version: PublishableEntityVersion) -> tomlki
     container_table.add("unit", unit_table)
     version_table.add("container", container_table)
     return version_table  # For use in AoT
+
+
+def toml_collection(collection: Collection) -> str:
+    """
+    Create a TOML representation of a collection.
+    The resulting content looks like:
+        [collection]
+        title = "Collection 1"
+        description = "Description of Collection 1"
+        created = 2025-09-03T17:50:59.565939Z
+
+        # ### Entities
+
+        [[entity]]
+        uuid = "f8ea9bae-b4ed-4a84-ab4f-2b9850b59cd6"
+        can_stand_alone = true
+        key = "xblock.v1:problem:my_published_example"
+    """
+    doc = tomlkit.document()
+
+    collection_table = tomlkit.table()
+    collection_table.add("title", collection.title)
+    collection_table.add("description", collection.description)
+    collection_table.add("created", collection.created)
+    doc.add("collection", collection_table)
+    doc.add(tomlkit.nl())
+    doc.add(tomlkit.comment("### Entities"))
+    # Entity serialization
+    for entity in collection.entities.all():
+        entities_array = tomlkit.aot()
+        entity_table = _get_toml_publishable_entity_table(entity, include_versions=False)
+        entities_array.append(entity_table)
+        doc.add("entity", entities_array)
+
+    return tomlkit.dumps(doc)

--- a/openedx_learning/apps/authoring/backup_restore/toml.py
+++ b/openedx_learning/apps/authoring/backup_restore/toml.py
@@ -178,10 +178,9 @@ def toml_collection(collection: Collection) -> str:
     """
     doc = tomlkit.document()
 
-    entity_keys = collection.entities.values_list("key", flat=True)
+    entity_keys = collection.entities.order_by("key").values_list("key", flat=True)
     entities_array = tomlkit.array()
-    for entity_key in entity_keys:
-        entities_array.append(entity_key)
+    entities_array.extend(entity_keys)
     entities_array.multiline(True)
 
     collection_table = tomlkit.table()

--- a/openedx_learning/apps/authoring/backup_restore/toml.py
+++ b/openedx_learning/apps/authoring/backup_restore/toml.py
@@ -15,6 +15,7 @@ from openedx_learning.apps.authoring.publishing.models.learning_package import L
 def toml_learning_package(learning_package: LearningPackage) -> str:
     """
     Create a TOML representation of the learning package.
+
     The resulting content looks like:
         # Datetime of the export: 2025-09-03 12:50:59.573253
 
@@ -42,6 +43,7 @@ def _get_toml_publishable_entity_table(
         include_versions: bool = True) -> tomlkit.items.Table:
     """
     Create a TOML representation of a publishable entity.
+
     The resulting content looks like:
         [entity]
         uuid = "f8ea9bae-b4ed-4a84-ab4f-2b9850b59cd6"
@@ -53,6 +55,9 @@ def _get_toml_publishable_entity_table(
 
         [entity.published]
         version_num = 1
+
+    Note: This function returns a tomlkit.items.Table, which represents
+    a string-like TOML fragment rather than a complete TOML document.
     """
     entity_table = tomlkit.table()
     entity_table.add("uuid", str(entity.uuid))
@@ -83,6 +88,7 @@ def _get_toml_publishable_entity_table(
 def toml_publishable_entity(entity: PublishableEntity) -> str:
     """
     Create a TOML representation of a publishable entity and its versions.
+
     The resulting content looks like:
         [entity]
         uuid = "f8ea9bae-b4ed-4a84-ab4f-2b9850b59cd6"
@@ -126,6 +132,7 @@ def toml_publishable_entity(entity: PublishableEntity) -> str:
 def toml_publishable_entity_version(version: PublishableEntityVersion) -> tomlkit.items.Table:
     """
     Create a TOML representation of a publishable entity version.
+
     The resulting content looks like:
         [[version]]
         title = "My published problem"
@@ -137,6 +144,9 @@ def toml_publishable_entity_version(version: PublishableEntityVersion) -> tomlki
 
         [version.container.unit]
         graded = true
+
+     Note: This function returns a tomlkit.items.Table, which represents
+    a string-like TOML fragment rather than a complete TOML document.
     """
     version_table = tomlkit.table()
     version_table.add("title", version.title)
@@ -154,6 +164,7 @@ def toml_publishable_entity_version(version: PublishableEntityVersion) -> tomlki
 def toml_collection(collection: Collection) -> str:
     """
     Create a TOML representation of a collection.
+
     The resulting content looks like:
         [collection]
         title = "Collection 1"
@@ -173,9 +184,11 @@ def toml_collection(collection: Collection) -> str:
     collection_table.add("title", collection.title)
     collection_table.add("description", collection.description)
     collection_table.add("created", collection.created)
+
     doc.add("collection", collection_table)
     doc.add(tomlkit.nl())
     doc.add(tomlkit.comment("### Entities"))
+
     # Entity serialization
     for entity in collection.entities.all():
         entities_array = tomlkit.aot()

--- a/openedx_learning/apps/authoring/backup_restore/zipper.py
+++ b/openedx_learning/apps/authoring/backup_restore/zipper.py
@@ -163,8 +163,11 @@ class LearningPackageZipper:
             for entity in publishable_entities:
                 # entity: PublishableEntity = entity  # Type hint for clarity
 
+                # Get the draft and published versions
+                versions_to_write: List[PublishableEntityVersion] = self.get_versions_to_write(entity)
+
                 # Create a TOML representation of the entity
-                entity_toml_content: str = toml_publishable_entity(entity)
+                entity_toml_content: str = toml_publishable_entity(entity, versions_to_write)
 
                 if hasattr(entity, 'container'):
                     entity_slugify_hash = slugify_hashed_filename(entity.key)
@@ -214,11 +217,7 @@ class LearningPackageZipper:
                     self.create_folder(component_version_folder, zipf)
 
                     # ------ COMPONENT VERSIONING -------------
-                    # Focusing on draft and published versions
-
-                    # Get the draft and published versions
-                    versions_to_write: List[PublishableEntityVersion] = self.get_versions_to_write(entity)
-
+                    # Focusing on draft and published versions only
                     for version in versions_to_write:
                         # Create a folder for the version
                         version_number = f"v{version.version_num}"

--- a/tests/openedx_learning/apps/authoring/backup_restore/test_backup.py
+++ b/tests/openedx_learning/apps/authoring/backup_restore/test_backup.py
@@ -122,6 +122,20 @@ class LpDumpCommandTestCase(TestCase):
         components = api.get_publishable_entities(cls.learning_package)
         cls.all_components = components
 
+        cls.collection1 = api.create_collection(
+            cls.learning_package.id,
+            key="COL1",
+            created_by=cls.user.id,
+            title="Collection 1",
+            description="Description of Collection 1",
+        )
+
+        api.add_to_collection(
+            cls.learning_package.id,
+            cls.collection1.key,
+            components
+        )
+
     def check_toml_file(self, zip_path: Path, zip_member_name: Path, content_to_check: list):
         """
         Check that a specific entity TOML file in the zip matches the expected content.
@@ -157,6 +171,9 @@ class LpDumpCommandTestCase(TestCase):
                 # Entity static content files
                 "entities/xblock.v1/html/my_draft_example_af06e1/component_versions/v2/static/hello.html",
                 "entities/xblock.v1/problem/my_published_example_386dce/component_versions/v2/hello.txt",
+
+                # Collections
+                "collections/col1_06bb25.toml",
             ]
 
             expected_paths = expected_directories + expected_files

--- a/tests/openedx_learning/apps/authoring/backup_restore/test_backup.py
+++ b/tests/openedx_learning/apps/authoring/backup_restore/test_backup.py
@@ -11,7 +11,7 @@ from django.core.management import CommandError, call_command
 from django.db.models import QuerySet
 
 from openedx_learning.api import authoring as api
-from openedx_learning.api.authoring_models import Component, LearningPackage
+from openedx_learning.api.authoring_models import Collection, Component, Content, LearningPackage, PublishableEntity
 from openedx_learning.apps.authoring.backup_restore.zipper import LearningPackageZipper
 from openedx_learning.lib.test_utils import TestCase
 
@@ -24,7 +24,15 @@ class LpDumpCommandTestCase(TestCase):
     """
 
     learning_package: LearningPackage
-    all_components: QuerySet[Component]
+    all_components: QuerySet[PublishableEntity]
+    now: datetime
+    xblock_v1_namespace: str
+    html_type: str
+    problem_type: str
+    published_component: Component
+    draft_component: Component
+    html_asset_content: Content
+    collection: Collection
 
     @classmethod
     def setUpTestData(cls):
@@ -122,7 +130,7 @@ class LpDumpCommandTestCase(TestCase):
         components = api.get_publishable_entities(cls.learning_package)
         cls.all_components = components
 
-        cls.collection1 = api.create_collection(
+        cls.collection = api.create_collection(
             cls.learning_package.id,
             key="COL1",
             created_by=cls.user.id,
@@ -132,7 +140,7 @@ class LpDumpCommandTestCase(TestCase):
 
         api.add_to_collection(
             cls.learning_package.id,
-            cls.collection1.key,
+            cls.collection.key,
             components
         )
 


### PR DESCRIPTION
## Description
Resolves https://github.com/openedx/openedx-learning/issues/361
This PR adds support for serializing **collections** into the learning package dump file.

### Key Changes
- Each collection is serialized as a **TOML file** within the dump folder.  
- Added a `prefetch_related` query on the collections queryset to improve performance.  
- When generating collection TOML files, related **entities** are included, but their **versions** are not.  

### Example Output

Filename: col1_06bb25.toml

```toml
[collection]
title = "Collection 1"
description = "Description of Collection 1"
created = 2025-09-03T18:56:57.524111Z

# ### Entities

[[entity]]
uuid = "4ebf2668-75e2-4e27-b339-33b45fd2a087"
can_stand_alone = true
key = "xblock.v1:problem:my_published_example"

[[entity]]
uuid = "a068659e-27ea-4495-82ad-9d0bf11d64da"
can_stand_alone = true
key = "xblock.v1:html:my_draft_example"