### PR TITLE
chore: bump version to 0.28.0

### DIFF
--- a/openedx_learning/__init__.py
+++ b/openedx_learning/__init__.py
@@ -2,4 +2,4 @@
 Open edX Learning ("Learning Core").
 """
 
-__version__ = "0.27.1"
+__version__ = "0.28.0"


### PR DESCRIPTION
It's been a few weeks since we've pushed out a new version. This includes the `backup_restore` app and postgresql support.