### PR TITLE
feat: get complete entity structure api

### DIFF
--- a/openedx_learning/apps/authoring/publishing/models/draft_log.py
+++ b/openedx_learning/apps/authoring/publishing/models/draft_log.py
@@ -56,6 +56,9 @@ class Draft(models.Model):
         blank=True,
     )
 
+    def __str__(self):
+        return f"Draft of {self.entity}"
+
 
 class DraftChangeLog(models.Model):
     """


### PR DESCRIPTION
Adds function to get full structure of any container. Also creates a new api function to get ready to publish drafts and remove some duplicate code.

These changes are required by https://github.com/openedx/edx-platform/pull/37552 to allow publishing of containers more than one level deep, i.e. support any level, sections > subsections > units > components.

**Related PR:** https://github.com/openedx/edx-platform/pull/37552
**Related Issue:** https://github.com/openedx/frontend-app-authoring/issues/2502

**Concern:** The publish log without the changes in this PR stores the container draft that was published even if the container itself did not have any changes.

For Example: Suppose a structure like this: Section > Subsection > Unit > Component. If the component is updated and the section is published, the publish logs record the last draft of the section even if it has not changes of its own, i.e. its version number does not change.

Now with the changes in this PR and https://github.com/openedx/edx-platform/pull/37552, the publish log stores only the modified component and not the container that was published.

It is however possible to store the container as well as the actually updated component in the publish records if required.
