### PR TITLE
Drop support for Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]  # Add macos-latest later?
         python-version: ['3.11', '3.12']
-        toxenv: ["django42", "django52", "package", "quality"]
-        # We're only testing against MySQL 8 right now because 5.7 is
-        # incompatible with Djagno 4.2. We'd have to make the tox.ini file more
-        # complicated than it's worth given the short expected shelf-life of
-        # MySQL 5.7 in our stack.
+        toxenv: ["django52", "package", "quality"]
         mysql-version: ["8"]
     services:
       mysql:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42,52}, quality, docs, pii_check, lint-imports
+envlist = py{311,312}-django{52}, quality, docs, pii_check, lint-imports
 
 [doc8]
 ; D001 = Line too long
@@ -38,11 +38,10 @@ norecursedirs = .* docs requirements site-packages
 usedevelop = True  # installs -e .
 deps =
     setuptools
-    django42: Django>=4.2,<5.0
     django52: Django>=5.2,<6.0
     -r{toxinidir}/requirements/test.txt
 setenv =
-    # Note that the django32/django42 targets use MySQL, but running pytest by
+    # Note that the django* targets use MySQL, but running pytest by
     # itself (without tox) will run tests in SQLite for developer convenience.
     DJANGO_SETTINGS_MODULE = mysql_test_settings
 commands =


### PR DESCRIPTION
Since `openedx-platform` is only using Django 5.2 at the moment, there is no reason to continue supporting Django < 5.2 in this package.

I'm not sure if this is a `feat!` or a `build` commit.