### PR TITLE
fix: Migrate `LanguagesTaxnomy._taxonomy_class` to reflect refactoring

### DIFF
--- a/src/openedx_core/__init__.py
+++ b/src/openedx_core/__init__.py
@@ -6,4 +6,4 @@ The public APIs belong to the specific apps (openedx_content, openedx_tagging, e
 """
 
 # The version for the entire repository
-__version__ = "0.34.1"
+__version__ = "0.34.2"

--- a/src/openedx_tagging/migrations/0012_language_taxonomy.py
+++ b/src/openedx_tagging/migrations/0012_language_taxonomy.py
@@ -18,7 +18,7 @@ def create_language_taxonomy(apps, schema_editor):
         "allow_multiple": False,
         "allow_free_text": False,
         "visible_to_authors": True,
-        "_taxonomy_class": "openedx_tagging.models.system_defined.LanguageTaxonomy",
+        "_taxonomy_class": "openedx_tagging.core.tagging.models.system_defined.LanguageTaxonomy",
     })
 
     # But delete any unused tags created by the old fixture:

--- a/src/openedx_tagging/migrations/0019_language_taxonomy_class.py
+++ b/src/openedx_tagging/migrations/0019_language_taxonomy_class.py
@@ -1,0 +1,33 @@
+"""
+Data migration to update the _taxonomy_class on the Languages system taxonomy
+to reflect the new module path after the package rename.
+
+Old: openedx_tagging.core.tagging.models.system_defined.LanguageTaxonomy
+New: openedx_tagging.models.system_defined.LanguageTaxonomy
+"""
+
+from django.db import migrations
+
+OLD_CLASS = "openedx_tagging.core.tagging.models.system_defined.LanguageTaxonomy"
+NEW_CLASS = "openedx_tagging.models.system_defined.LanguageTaxonomy"
+
+
+def update_language_taxonomy_class(apps, schema_editor):
+    Taxonomy = apps.get_model("oel_tagging", "Taxonomy")
+    Taxonomy.objects.filter(_taxonomy_class=OLD_CLASS).update(_taxonomy_class=NEW_CLASS)
+
+
+def revert_language_taxonomy_class(apps, schema_editor):
+    Taxonomy = apps.get_model("oel_tagging", "Taxonomy")
+    Taxonomy.objects.filter(_taxonomy_class=NEW_CLASS).update(_taxonomy_class=OLD_CLASS)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("oel_tagging", "0018_objecttag_is_copied"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_language_taxonomy_class, revert_language_taxonomy_class),
+    ]


### PR DESCRIPTION
Fixes an error along the lines of:
      Unable to import taxonomy_class for -1:
      openedx_tagging.core.tagging.models.system_defined.LanguageTaxonomy

This was missed in: https://github.com/openedx/openedx-core/issues/470

We had updated migration 0012 to initialize LanguagesTaxonomy with the post-refactoring _taxonomy_class, but didn't add a new data migration to fix the classpath. Migration 0019 now fixes that.
This commit also reverts our change to 0012 for the sake of historical continuity (but it doesn't really matter either way since 0019 will overwrite the _taxonomy_class).

Bumps patch version.

openedx-platform companion PR:
* https://github.com/openedx/openedx-platform/pull/38035

___________

Tested by looking at django admin before running the migration and confirming the class path is wrong, running the migration, and then checking to see that it's fixed.


<img width="471" height="71" alt="Screenshot 2026-02-20 at 3 33 44 PM" src="https://github.com/user-attachments/assets/5be67a98-3d87-45d4-8584-52c30d91b916" />

```
Running migrations:
  Applying oel_tagging.0019_language_taxonomy_class... OK
```

<img width="471" height="71" alt="Screenshot 2026-02-20 at 3 34 26 PM" src="https://github.com/user-attachments/assets/671aeb42-cff7-405f-8f4c-27fc21a070e9" />

___________

Claude Code wrote the migration file. Only change I made was to remove `id=-1` from `Taxonomy.objects.filter(...)`, which Claude had originally included alongside the `OLD_CLASS` and `NEW_CLASS` filters. I'd like this migration to update any entry in the table whose `_taxonomy_class` points at the old LanguageTaxonomy class.