### PR TITLE
build: Restore py.typed so that our code exports with typing info

### DIFF
--- a/src/openedx_content/py.typed
+++ b/src/openedx_content/py.typed
@@ -1,0 +1,2 @@
+# The presence of this file tells Python that this entire package includes type information.
+

--- a/src/openedx_django_lib/py.typed
+++ b/src/openedx_django_lib/py.typed
@@ -1,0 +1,2 @@
+# The presence of this file tells Python that this entire package includes type information.
+


### PR DESCRIPTION
I missed these when implementing:
* #470 