### PR TITLE
feat: typed PK identifiers for Units/Subsections/Sections

### DIFF
--- a/src/openedx_content/applets/sections/api.py
+++ b/src/openedx_content/applets/sections/api.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Iterable
 
 from ..containers import api as containers_api
-from ..containers.models import Container, ContainerVersion
+from ..containers.models import ContainerVersion
 from ..publishing.models import LearningPackage
 from ..subsections.models import Subsection, SubsectionVersion
 from .models import Section, SectionVersion
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-def get_section(section_id: Container.PK, /):
+def get_section(section_id: Section.PK, /):
     """Get a section"""
     return Section.objects.select_related("container").get(pk=section_id)
 
@@ -61,7 +61,7 @@ def create_section_and_version(
 
 
 def create_next_section_version(
-    section: Section | Container.PK,
+    section: Section | Section.PK,
     *,
     title: str | None = None,
     subsections: Iterable[Subsection | SubsectionVersion] | None = None,

--- a/src/openedx_content/applets/sections/models.py
+++ b/src/openedx_content/applets/sections/models.py
@@ -2,13 +2,13 @@
 Models that implement sections
 """
 
-from typing import override
+from typing import NewType, TypeAlias, cast, override
 
 from django.core.exceptions import ValidationError
 from django.db import models
 
 from ..containers.api import get_container_subclass_of
-from ..containers.models import Container, ContainerVersion
+from ..containers.models import Container, ContainerPK, ContainerVersion
 from ..publishing.models import PublishableEntity
 from ..subsections.models import Subsection
 
@@ -16,6 +16,8 @@ __all__ = [
     "Section",
     "SectionVersion",
 ]
+
+SectionPK = NewType("SectionPK", ContainerPK)
 
 
 @Container.register_subclass
@@ -27,6 +29,8 @@ class Section(Container):
     entities and can be added to other containers.
     """
 
+    PK: TypeAlias = SectionPK
+
     type_code = "section"
     olx_tag_name = "chapter"  # Serializes to OLX as `<chapter>...</chapter>`.
 
@@ -36,6 +40,10 @@ class Section(Container):
         parent_link=True,
         primary_key=True,
     )
+
+    @property
+    def id(self) -> SectionPK:
+        return cast(SectionPK, self.publishable_entity_id)
 
     @override
     @classmethod

--- a/src/openedx_content/applets/subsections/api.py
+++ b/src/openedx_content/applets/subsections/api.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Iterable
 
 from ..containers import api as containers_api
-from ..containers.models import Container, ContainerVersion
+from ..containers.models import ContainerVersion
 from ..publishing.models import LearningPackage
 from ..units.models import Unit, UnitVersion
 from .models import Subsection, SubsectionVersion
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-def get_subsection(subsection_id: Container.PK, /):
+def get_subsection(subsection_id: Subsection.PK, /):
     """Get a subsection"""
     return Subsection.objects.select_related("container").get(pk=subsection_id)
 
@@ -61,7 +61,7 @@ def create_subsection_and_version(
 
 
 def create_next_subsection_version(
-    subsection: Subsection | Container.PK,
+    subsection: Subsection | Subsection.PK,
     *,
     title: str | None = None,
     units: Iterable[Unit | UnitVersion] | None = None,

--- a/src/openedx_content/applets/subsections/models.py
+++ b/src/openedx_content/applets/subsections/models.py
@@ -2,13 +2,13 @@
 Models that implement subsections
 """
 
-from typing import override
+from typing import NewType, TypeAlias, cast, override
 
 from django.core.exceptions import ValidationError
 from django.db import models
 
 from ..containers.api import get_container_subclass_of
-from ..containers.models import Container, ContainerVersion
+from ..containers.models import Container, ContainerPK, ContainerVersion
 from ..publishing.models import PublishableEntity
 from ..units.models import Unit
 
@@ -16,6 +16,8 @@ __all__ = [
     "Subsection",
     "SubsectionVersion",
 ]
+
+SubsectionPK = NewType("SubsectionPK", ContainerPK)
 
 
 @Container.register_subclass
@@ -27,6 +29,8 @@ class Subsection(Container):
     entities and can be added to other containers.
     """
 
+    PK: TypeAlias = SubsectionPK
+
     type_code = "subsection"
     olx_tag_name = "sequential"  # Serializes to OLX as `<sequential>...</sequential>`.
 
@@ -36,6 +40,10 @@ class Subsection(Container):
         parent_link=True,
         primary_key=True,
     )
+
+    @property
+    def id(self) -> SubsectionPK:
+        return cast(SubsectionPK, self.publishable_entity_id)
 
     @override
     @classmethod

--- a/src/openedx_content/applets/units/api.py
+++ b/src/openedx_content/applets/units/api.py
@@ -9,7 +9,7 @@ from typing import Iterable
 
 from ..components.models import Component, ComponentVersion
 from ..containers import api as containers_api
-from ..containers.models import Container, ContainerVersion
+from ..containers.models import ContainerVersion
 from ..publishing.models import LearningPackage
 from .models import Unit, UnitVersion
 
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-def get_unit(unit_id: Container.PK, /):
+def get_unit(unit_id: Unit.PK, /):
     """Get a unit"""
     return Unit.objects.select_related("container").get(pk=unit_id)
 
@@ -61,7 +61,7 @@ def create_unit_and_version(
 
 
 def create_next_unit_version(
-    unit: Unit | Container.PK,
+    unit: Unit | Unit.PK,
     *,
     title: str | None = None,
     components: Iterable[Component | ComponentVersion] | None = None,

--- a/src/openedx_content/applets/units/models.py
+++ b/src/openedx_content/applets/units/models.py
@@ -2,18 +2,20 @@
 Models that implement units
 """
 
-from typing import override
+from typing import NewType, TypeAlias, cast, override
 
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from ..containers.models import Container, ContainerVersion
+from ..containers.models import Container, ContainerPK, ContainerVersion
 from ..publishing.models import PublishableEntity
 
 __all__ = [
     "Unit",
     "UnitVersion",
 ]
+
+UnitPK = NewType("UnitPK", ContainerPK)
 
 
 @Container.register_subclass
@@ -25,6 +27,8 @@ class Unit(Container):
     entities and can be added to other containers.
     """
 
+    PK: TypeAlias = UnitPK
+
     type_code = "unit"
     olx_tag_name = "vertical"  # Serializes to OLX as `<unit>...</unit>`.
 
@@ -34,6 +38,10 @@ class Unit(Container):
         parent_link=True,
         primary_key=True,
     )
+
+    @property
+    def id(self) -> UnitPK:
+        return cast(UnitPK, self.publishable_entity_id)
 
     @override
     @classmethod

--- a/tests/openedx_content/applets/sections/test_api.py
+++ b/tests/openedx_content/applets/sections/test_api.py
@@ -8,7 +8,7 @@ import pytest
 from django.core.exceptions import ValidationError
 
 import openedx_content.api as content_api
-from openedx_content.models_api import Container, Section, SectionVersion, Subsection, SubsectionVersion
+from openedx_content.models_api import Section, SectionVersion, Subsection, SubsectionVersion
 
 from ..components.test_api import ComponentTestCase
 
@@ -140,14 +140,14 @@ class SectionsTestCase(ComponentTestCase):
 
     def test_get_section_nonexistent(self) -> None:
         """Test `get_section()` when the subsection doesn't exist"""
-        FAKE_ID = cast(Container.PK, -500)
+        FAKE_ID = cast(Section.PK, -500)
         with pytest.raises(Section.DoesNotExist):
             content_api.get_section(FAKE_ID)
 
     def test_get_section_other_container_type(self) -> None:
         """Test `get_section()` when the provided PK is for a non-Subsection container"""
         with pytest.raises(Section.DoesNotExist):
-            content_api.get_section(self.unit_1.id)
+            content_api.get_section(self.unit_1.id)  # type: ignore[arg-type]
 
     def test_section_queries(self) -> None:
         """

--- a/tests/openedx_content/applets/subsections/test_api.py
+++ b/tests/openedx_content/applets/subsections/test_api.py
@@ -1,13 +1,14 @@
 """
 Basic tests for the subsections API.
 """
+
 from typing import cast
 
 import pytest
 from django.core.exceptions import ValidationError
 
 import openedx_content.api as content_api
-from openedx_content.models_api import Container, Subsection, SubsectionVersion, Unit, UnitVersion
+from openedx_content.models_api import Subsection, SubsectionVersion, Unit, UnitVersion
 
 from ..components.test_api import ComponentTestCase
 
@@ -117,14 +118,14 @@ class SubsectionsTestCase(ComponentTestCase):
 
     def test_get_subsection_nonexistent(self) -> None:
         """Test `get_subsection()` when the subsection doesn't exist"""
-        FAKE_ID = cast(Container.PK, -500)
+        FAKE_ID = cast(Subsection.PK, -500)
         with pytest.raises(Subsection.DoesNotExist):
             content_api.get_subsection(FAKE_ID)
 
     def test_get_subsection_other_container_type(self) -> None:
         """Test `get_subsection()` when the provided PK is for a non-Subsection container"""
         with pytest.raises(Subsection.DoesNotExist):
-            content_api.get_subsection(self.unit_1.id)
+            content_api.get_subsection(self.unit_1.id)  # type: ignore[arg-type]
 
     def test_subsection_queries(self) -> None:
         """

--- a/tests/openedx_content/applets/units/test_api.py
+++ b/tests/openedx_content/applets/units/test_api.py
@@ -1,13 +1,14 @@
 """
 Basic tests for the units API.
 """
+
 from typing import cast
 
 import pytest
 from django.core.exceptions import ValidationError
 
 import openedx_content.api as content_api
-from openedx_content.models_api import Component, ComponentVersion, Container, Unit, UnitVersion
+from openedx_content.models_api import Component, ComponentVersion, Unit, UnitVersion
 from tests.test_django_app.models import TestContainer
 
 from ..components.test_api import ComponentTestCase
@@ -111,7 +112,7 @@ class UnitsTestCase(ComponentTestCase):
 
     def test_get_unit_nonexistent(self) -> None:
         """Test `get_unit()` when the unit doesn't exist"""
-        FAKE_ID = cast(Container.PK, -500)
+        FAKE_ID = cast(Unit.PK, -500)
         with pytest.raises(Unit.DoesNotExist):
             content_api.get_unit(FAKE_ID)
 
@@ -125,7 +126,7 @@ class UnitsTestCase(ComponentTestCase):
             container_cls=TestContainer,
         )
         with pytest.raises(Unit.DoesNotExist):
-            content_api.get_unit(other_container.id)
+            content_api.get_unit(other_container.id)  # type: ignore[arg-type]
 
     def test_unit_queries(self) -> None:
         """


### PR DESCRIPTION
This is an optional extension to https://github.com/openedx/openedx-core/pull/534 which further breaks `Container.PK` down into `Unit.PK`, `Subsection.PK`, `Section.PK` key types.

For now it works smoothly and has a very small diff to implement. But I am worried that it could add more complexity (and require more casting) than it's worth down the road? Hard to say. Since we don't have much difference between the container types at the moment, I'm not sure what the trade-offs are here.