### PR TITLE
feat: extract overridable permission methods from ObjectTagView

### DIFF
--- a/src/openedx_core/__init__.py
+++ b/src/openedx_core/__init__.py
@@ -6,4 +6,4 @@ The public APIs belong to the specific apps (openedx_content, openedx_tagging, e
 """
 
 # The version for the entire repository
-__version__ = "0.39.2"
+__version__ = "0.40.0"

--- a/src/openedx_tagging/rest_api/v1/serializers.py
+++ b/src/openedx_tagging/rest_api/v1/serializers.py
@@ -172,6 +172,14 @@ class ObjectTagsByTaxonomySerializer(UserPermissionsSerializerMixin, serializers
     class Meta:
         model = ObjectTag
 
+    def get_can_tag_object(self, obj_tag) -> bool | None:
+        """
+        Returns True if the current request user may tag objects with this taxonomy.
+        Override to customize permission logic.
+        """
+        perm_name = f"{self.app_label}.can_tag_object"
+        return self._can(perm_name, obj_tag)
+
     def to_representation(self, instance: list[ObjectTag]) -> dict:
         """
         Convert this list of ObjectTags to the serialized dictionary, grouped by Taxonomy
@@ -179,7 +187,6 @@ class ObjectTagsByTaxonomySerializer(UserPermissionsSerializerMixin, serializers
         # Allows consumers like edx-platform to override this
         ObjectTagViewMinimalSerializer = self.context["view"].minimal_serializer_class
 
-        can_tag_object_perm = f"{self.app_label}.can_tag_object"
         by_object: dict[str, dict[str, Any]] = {}
         for obj_tag in instance:
             if obj_tag.object_id not in by_object:
@@ -192,7 +199,7 @@ class ObjectTagsByTaxonomySerializer(UserPermissionsSerializerMixin, serializers
                 tax_entry = {
                     "name": obj_tag.taxonomy.name if obj_tag.taxonomy else None,
                     "taxonomy_id": obj_tag.taxonomy_id,
-                    "can_tag_object": self._can(can_tag_object_perm, obj_tag),
+                    "can_tag_object": self.get_can_tag_object(obj_tag),
                     "tags": [],
                     "export_id": obj_tag.export_id,
                 }

--- a/src/openedx_tagging/rest_api/v1/views.py
+++ b/src/openedx_tagging/rest_api/v1/views.py
@@ -450,9 +450,42 @@ class ObjectTagView(
     serializer_class = ObjectTagSerializer
     # Serializer used in the result in `to_representation` in `ObjectTagsByTaxonomySerializer`
     minimal_serializer_class = ObjectTagMinimalSerializer
+    # Serializer used in `retrieve` to group object tags by taxonomy
+    taxonomy_serializer_class = ObjectTagsByTaxonomySerializer
     permission_classes = [ObjectTagObjectPermissions]
     lookup_field = "object_id"
     lookup_value_regex = r'[\w\.\+\-@:]+'
+
+    def check_view_object_tags_permission(self, object_id: str, taxonomy=None) -> None:
+        """
+        Check if the current user can view object tags for the given object.
+        Raises PermissionDenied if not. Override to customize permission logic.
+        """
+        perm_obj = ObjectTagPermissionItem(taxonomy=taxonomy, object_id=object_id)
+        if not self.request.user.has_perm(
+            "oel_tagging.view_objecttag",
+            # The obj arg expects a model, but we are passing an object
+            perm_obj,  # type: ignore[arg-type]
+        ):
+            raise PermissionDenied(
+                "You do not have permission to view object tags for this taxonomy or object_id."
+            )
+
+    def check_can_tag_object_permission(self, object_id: str, taxonomy) -> None:
+        """
+        Check if the current user can tag the given object with the given taxonomy.
+        Raises PermissionDenied if not. Override to customize permission logic.
+        """
+        perm_obj = ObjectTagPermissionItem(taxonomy=taxonomy, object_id=object_id)
+        if not self.request.user.has_perm(
+            "oel_tagging.can_tag_object",
+            # The obj arg expects a model, but we are passing an object
+            perm_obj,  # type: ignore[arg-type]
+        ):
+            raise PermissionDenied(f"""
+                You do not have permission to change object tags
+                for Taxonomy: {str(taxonomy)} or Object: {object_id}.
+            """)
 
     def get_queryset(self) -> models.QuerySet:
         """
@@ -477,14 +510,7 @@ class ObjectTagView(
             # objects, e.g. if object_id.endswith("*") then it results in a object_id__startswith query. However, for
             # now we have no use case for that so we retrieve tags for one object at a time.
         else:
-            if not self.request.user.has_perm(
-                "oel_tagging.view_objecttag",
-                # The obj arg expects a model, but we are passing an object
-                ObjectTagPermissionItem(taxonomy=taxonomy, object_id=object_id),  # type: ignore[arg-type]
-            ):
-                raise PermissionDenied(
-                    "You do not have permission to view object tags for this taxonomy or object_id."
-                )
+            self.check_view_object_tags_permission(object_id, taxonomy)
 
         return get_object_tags(object_id, taxonomy_id)
 
@@ -500,7 +526,7 @@ class ObjectTagView(
         behavior we want.
         """
         object_tags = self.filter_queryset(self.get_queryset())
-        serializer = ObjectTagsByTaxonomySerializer(list(object_tags), context=self.get_serializer_context())
+        serializer = self.taxonomy_serializer_class(list(object_tags), context=self.get_serializer_context())
         response_data = serializer.data
         if self.kwargs["object_id"] not in response_data:
             # For consistency, the key with the object_id should always be present in the response, even if there
@@ -556,7 +582,6 @@ class ObjectTagView(
             raise MethodNotAllowed("PATCH", detail="PATCH not allowed")
 
         object_id = kwargs.pop('object_id')
-        perm = "oel_tagging.can_tag_object"
         body = ObjectTagUpdateBodySerializer(data=request.data)
         body.is_valid(raise_exception=True)
 
@@ -568,20 +593,7 @@ class ObjectTagView(
         # Check permissions
         for tagsData in data:
             taxonomy = tagsData.get("taxonomy")
-
-            perm_obj = ObjectTagPermissionItem(
-                taxonomy=taxonomy,
-                object_id=object_id,
-            )
-            if not request.user.has_perm(
-                perm,
-                # The obj arg expects a model, but we are passing an object
-                perm_obj,  # type: ignore[arg-type]
-            ):
-                raise PermissionDenied(f"""
-                    You do not have permission to change object tags
-                    for Taxonomy: {str(taxonomy)} or Object: {object_id}.
-                """)
+            self.check_can_tag_object_permission(object_id, taxonomy)
 
         # Tag object_id per taxonomy
         for tagsData in data:


### PR DESCRIPTION
## Extract overridable permission methods from ObjectTagView

### Context

As part of the [RBAC AuthZ course authoring milestone](https://github.com/openedx/openedx-authz/issues/181), edx-platform needs to substitute openedx-authz permission checks for the legacy django-rules checks on content tagging endpoints. The current `ObjectTagView` inlines its permission logic, forcing downstream overrides to duplicate significant parent view code — which is fragile and hard to maintain.

### Changes

**`views.py`** — Extract 2 overridable access-control methods from `ObjectTagView`:

| Method | Called from | Purpose |
|---|---|---|
| `check_view_object_tags_permission(object_id, taxonomy)` | `get_queryset` | Gate read access to object tags |
| `check_can_tag_object_permission(object_id, taxonomy)` | `update` | Gate write access |

**`serializers.py`** — Extract 1 overridable method for response-field permission computation:

| Method | Serializer | Purpose |
|---|---|---|
| `get_can_tag_object(obj_tag)` | `ObjectTagsByTaxonomySerializer` | Compute `can_tag_object` bool for response |

`ObjectTagMinimalSerializer.get_can_delete_objecttag` was already overridable — no changes needed.

All default implementations preserve existing behavior exactly.

### Design

Access-control checks (`check_*`) live on the view — they gate endpoint access from `get_queryset` and `update`. Response-field computation (`get_can_tag_object`, `get_can_delete_objecttag`) lives on the serializers, consistent with how all other permission fields (`can_change_taxonomy`, `can_delete_tag`, etc.) work in this package. This keeps a clean separation: views own access control, serializers own data representation.

### Why

This lets downstream platforms (e.g., edx-platform) override permission logic without duplicating `get_queryset`, `update`, or `retrieve` code. The companion edx-platform PR is [openedx/openedx-platform#38292](https://github.com/openedx/openedx-platform/pull/38292).

### Testing

- No behavior change for existing consumers — all existing tests pass without modification.
- Integration-tested via the companion edx-platform: PR https://github.com/openedx/openedx-platform/pull/38292.

*Co-authored with [Kiro](https://kiro.dev/)*
