### PR TITLE
fix: TypeError when restoring published containers

### DIFF
--- a/src/openedx_content/applets/backup_restore/zipper.py
+++ b/src/openedx_content/applets/backup_restore/zipper.py
@@ -829,13 +829,12 @@ class LearningPackageUnzipper:
         for valid_published in containers.get(f"{type_code}_published", []):
             entity_key = valid_published.pop("entity_key")
             children = self._resolve_children(valid_published, children_map)
-            self.all_published_entities_versions.add(
-                (entity_key, valid_published.get('version_num'))
-            )  # Track published version
+            version_num = valid_published.pop("version_num", None)
+            self.all_published_entities_versions.add((entity_key, version_num))
             containers_api.create_next_container_version(
                 container_map[entity_key],
+                force_version_num=version_num,
                 **valid_published,  # should this be allowed to override any of the following fields?
-                force_version_num=valid_published.pop("version_num", None),
                 entities=children,
                 created_by=self.user_id,
             )

--- a/src/openedx_core/__init__.py
+++ b/src/openedx_core/__init__.py
@@ -6,4 +6,4 @@ The public APIs belong to the specific apps (openedx_content, openedx_tagging, e
 """
 
 # The version for the entire repository
-__version__ = "0.39.2"
+__version__ = "0.40.0"

--- a/tests/openedx_content/applets/backup_restore/fixtures/library_backup/entities/unit1-b7eafb.toml
+++ b/tests/openedx_content/applets/backup_restore/fixtures/library_backup/entities/unit1-b7eafb.toml
@@ -7,7 +7,7 @@ created = 2025-09-04T22:51:59.271334Z
 version_num = 2
 
 [entity.published]
-# unpublished: no published_version_num
+version_num = 2
 
 [entity.container.unit]
 

--- a/tests/openedx_content/applets/backup_restore/test_restore.py
+++ b/tests/openedx_content/applets/backup_restore/test_restore.py
@@ -66,13 +66,19 @@ class RestoreLearningPackageCommandTest(RestoreTestCase):
             published_version = publishing_api.get_published_version(container.publishable_entity.id)
             assert container.created_by is not None
             assert container.created_by.username == "lp_user"
+            # The unit has been published. The other two containers haven't been.
+            # It's important that we test with at least one published container in order to
+            # fully cover _create_container in zipper.py.
             if container.key == "unit1-b7eafb":
                 assert containers_api.get_container_type_code_of(container) == "unit"
                 assert draft_version is not None
                 assert draft_version.version_num == 2
                 assert draft_version.created_by is not None
                 assert draft_version.created_by.username == "lp_user"
-                assert published_version is None
+                assert published_version is not None
+                assert published_version.version_num == 2
+                assert published_version.created_by is not None
+                assert published_version.created_by.username == "lp_user"
             elif container.key == "subsection1-48afa3":
                 assert containers_api.get_container_type_code_of(container) == "subsection"
                 assert draft_version is not None


### PR DESCRIPTION
## Description

The original version of this code depended upon `version_num` being popped out
of `valid_published` before `valid_published` got expanded. A [recent change](https://github.com/openedx/openedx-core/pull/495)
changed the argument order, leading to:

    TypeError: create_next_container_version() got an unexpected keyword argument
    'version_num'

whenever restoring an archive with any published containers. This commit
restores the original code's order of operations, but a bit more explicitly.

Bumps from 0.39.2 to 0.40.0 (it would be 0.39.3, but the previous
commit had breaking changes and neglected to bump the minor version)

## Testing

On openedx-platform master and openedx-core==v0.39.0, back up any library with at least one published component.

Try to restore it. It'll fail. You should see a TypeError in the logs.

Cherry-pick this commit on top of openedx-core v0.39.0. Try again to restore the archive. It should succeed.
