### PR TITLE
test: Ensure back-compat of new _code fields in TOML archives

### DIFF
--- a/tests/openedx_learning/apps/authoring/backup_restore/fixtures/library_backup/entities/subsection1-48afa3.toml
+++ b/tests/openedx_learning/apps/authoring/backup_restore/fixtures/library_backup/entities/subsection1-48afa3.toml
@@ -9,7 +9,14 @@ version_num = 2
 [entity.published]
 # unpublished: no published_version_num
 
+# Starting with https://github.com/openedx/openedx-core/pull/545,
+# containers will derive their identity from `container_code` instead of
+# from `key` (although archives without a `container_code` will fall back
+# to `key`). We're adding this bit to the test fixture ahead of time to
+# ensure that older (Ulmo) code is forward-compatible with archives
+# containing `container_code`.
 [entity.container.subsection]
+container_code = "subsection1-48afa3"
 
 # ### Versions
 

--- a/tests/openedx_learning/apps/authoring/backup_restore/fixtures/library_backup/entities/xblock.v1/html/c22b9f97-f1e9-4e8f-87f0-d5a3c26083e2.toml
+++ b/tests/openedx_learning/apps/authoring/backup_restore/fixtures/library_backup/entities/xblock.v1/html/c22b9f97-f1e9-4e8f-87f0-d5a3c26083e2.toml
@@ -9,6 +9,16 @@ version_num = 2
 [entity.published]
 version_num = 2
 
+# Starting with https://github.com/openedx/openedx-core/pull/544,
+# components will derive their type and code from these attributes rather
+# than by parsing `key` (although archives without an [entity.component] section
+# will fall back to parsing `key`). We're adding this bit to the test fixture
+# early, ensuring that older (Ulmo) code is forward-compatible with archives
+# containing the [entity.component] section.
+[entity.component]
+component_type = "xblock.v1:html"
+component_code = "c22b9f97-f1e9-4e8f-87f0-d5a3c26083e2"
+
 # ### Versions
 
 [[version]]


### PR DESCRIPTION
[Do Not Merge]

This is a test PR to see how changes to the backup-restore format in #544 and #545 would work on Ulmo instance.

This PR is based on v0.30.2, which is what `release/ulmo` pins.

Context: https://github.com/openedx/openedx-core/pull/544#discussion_r3102780605