### PR TITLE
docs: remove incorrect comment

### DIFF
--- a/src/openedx_content/applets/publishing/models/publish_log.py
+++ b/src/openedx_content/applets/publishing/models/publish_log.py
@@ -172,10 +172,6 @@ class PublishLogRecord(models.Model):
     #   Components has unpublished changes, then "publish all" would cause the
     #   Component's record to have direct=True and the Unit's record to have
     #   direct=False.
-    #
-    #   All PublishLogRecords in the PublishLog have direct=True. The "publish
-    #   all" operation is indistinguishable from bulk publishing and selecting
-    #   every single item.
     direct = models.BooleanField(
         null=True,
         blank=True,


### PR DESCRIPTION
This directly contradicts the (correct) paragraph above it, and was from
before I traced through the publishing code and realized what the actual
behavior was.
