### PR TITLE
Delete tag updates meilisearch

### DIFF
--- a/src/openedx_core/__init__.py
+++ b/src/openedx_core/__init__.py
@@ -6,4 +6,4 @@ The public APIs belong to the specific apps (openedx_content, openedx_tagging, e
 """
 
 # The version for the entire repository
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/src/openedx_tagging/signal_handlers.py
+++ b/src/openedx_tagging/signal_handlers.py
@@ -34,7 +34,8 @@ def _is_explicit_tag_delete(
     if isinstance(origin, Tag):
         return origin.pk == instance.pk
 
-    # No-op if the origin isn't a queryset of tags, since that would be unexpected and we don't want to risk emitting too many events.
+    # No-op if the origin isn't a queryset of tags, since that would be
+    # unexpected and we don't want to risk emitting too many events.
     if not isinstance(origin, QuerySet) or origin.model is not Tag:
         return False
 

--- a/src/openedx_tagging/signal_handlers.py
+++ b/src/openedx_tagging/signal_handlers.py
@@ -3,11 +3,40 @@
 from functools import partial
 
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models import QuerySet
+from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
-from openedx_tagging.models.base import Tag
-from openedx_tagging.tasks import emit_content_object_associations_changed_for_tag_task
+from openedx_tagging.models.base import ObjectTag, Tag
+from openedx_tagging.tasks import (
+    emit_content_object_associations_changed_for_object_ids_task,
+    emit_content_object_associations_changed_for_tag_task,
+)
+
+
+def _is_explicit_tag_delete(instance: Tag, origin: object, using: str | None) -> bool:
+    """
+    Return True only for tags explicitly targeted by the delete operation.
+
+    Descendants deleted via CASCADE are skipped here because the explicit root
+    tag's handler emits updates for the whole subtree.
+    """
+    if isinstance(origin, Tag):
+        return origin.pk == instance.pk
+
+    if not isinstance(origin, QuerySet) or origin.model is not Tag:
+        return False
+
+    explicit_tags = origin.using(using)
+    if not explicit_tags.filter(pk=instance.pk).exists():
+        return False
+
+    lineage_parts = instance.lineage.rstrip("\t").split("\t")
+    ancestor_lineages = ["\t".join(lineage_parts[:index]) + "\t" for index in range(1, len(lineage_parts))]
+    if not ancestor_lineages:
+        return True
+
+    return not explicit_tags.filter(lineage__in=ancestor_lineages).exists()
 
 
 @receiver(post_save, sender=Tag)
@@ -28,5 +57,38 @@ def tag_post_save(sender, **kwargs):  # pylint: disable=unused-argument
         partial(
             emit_content_object_associations_changed_for_tag_task.delay,
             tag_id=tag_id
-        )
+        ),
+    )
+
+
+@receiver(pre_delete, sender=Tag)
+def tag_pre_delete(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    If a tag is deleted, enqueue async event emission for all associated objects.
+    """
+    instance = kwargs.get("instance", None)
+    origin = kwargs.get("origin", None)
+    using = kwargs.get("using", None)
+
+    if instance is None or instance.id is None:
+        return
+
+    if not _is_explicit_tag_delete(instance, origin, using):
+        return
+
+    object_ids = list(
+        ObjectTag.objects.using(using)
+        .filter(tag__lineage__startswith=instance.lineage)
+        .values_list("object_id", flat=True)
+        .distinct()
+    )
+    if not object_ids:
+        return
+
+    transaction.on_commit(
+        partial(
+            emit_content_object_associations_changed_for_object_ids_task.delay,
+            object_ids=object_ids,
+        ),
+        using=using,
     )

--- a/src/openedx_tagging/signal_handlers.py
+++ b/src/openedx_tagging/signal_handlers.py
@@ -14,24 +14,41 @@ from openedx_tagging.tasks import (
 )
 
 
-def _is_explicit_tag_delete(instance: Tag, origin: object, using: str | None) -> bool:
+def _is_explicit_tag_delete(
+    instance: Tag,
+    origin: Tag | QuerySet[Tag] | None,
+    using: str | None,
+) -> bool:
     """
     Return True only for tags explicitly targeted by the delete operation.
 
     Descendants deleted via CASCADE are skipped here because the explicit root
     tag's handler emits updates for the whole subtree.
+
+    Args:
+        instance: The Tag being deleted.
+        origin: The source of the delete operation - either a Tag instance (for instance.delete())
+                or a QuerySet[Tag] (for queryset.delete()), or None for other origins.
+        using: The database alias to use for queries, passed from the Django signal.
     """
     if isinstance(origin, Tag):
         return origin.pk == instance.pk
 
+    # No-op if the origin isn't a queryset of tags, since that would be unexpected and we don't want to risk emitting too many events.
     if not isinstance(origin, QuerySet) or origin.model is not Tag:
         return False
 
+    # Check if this instance is in the set of explicitly-targeted tags. If not, it's being deleted
+    # as a CASCADE side-effect, so it's not explicit.
     explicit_tags = origin.using(using)
     if not explicit_tags.filter(pk=instance.pk).exists():
         return False
 
-    lineage_parts = instance.lineage.rstrip("\t").split("\t")
+    lineage_parts = instance.get_lineage()
+    # Build the tab-separated lineage strings for all ancestors to check if any of them are
+    # also in explicit_tags. If an ancestor was explicitly targeted, then this tag is a CASCADE
+    # side-effect, not explicitly deleted. For example, if lineage_parts is
+    # ["root", "parent", "child"], ancestor_lineages will be ["root\t", "root\tparent\t"].
     ancestor_lineages = ["\t".join(lineage_parts[:index]) + "\t" for index in range(1, len(lineage_parts))]
     if not ancestor_lineages:
         return True
@@ -70,6 +87,8 @@ def tag_pre_delete(sender, **kwargs):  # pylint: disable=unused-argument
     origin = kwargs.get("origin", None)
     using = kwargs.get("using", None)
 
+    # Return early if the instance is missing or hasn't been saved yet (no ID).
+    # In these cases, we can't proceed with the signal logic.
     if instance is None or instance.id is None:
         return
 

--- a/src/openedx_tagging/signal_handlers.py
+++ b/src/openedx_tagging/signal_handlers.py
@@ -34,10 +34,12 @@ def _is_explicit_tag_delete(
     if isinstance(origin, Tag):
         return origin.pk == instance.pk
 
-    # No-op if the origin isn't a queryset of tags, since that would be
-    # unexpected and we don't want to risk emitting too many events.
-    if not isinstance(origin, QuerySet) or origin.model is not Tag:
-        return False
+    # Fail fast if origin has an unexpected type so callsites don't silently
+    # skip event emission logic.
+    if not isinstance(origin, QuerySet):
+        raise TypeError(f"Expected origin to be Tag, QuerySet[Tag], or None; got {type(origin).__name__}")
+    if origin.model is not Tag:
+        raise TypeError(f"Expected origin queryset model Tag; got {origin.model.__name__}")
 
     # Check if this instance is in the set of explicitly-targeted tags. If not, it's being deleted
     # as a CASCADE side-effect, so it's not explicit.

--- a/src/openedx_tagging/tasks.py
+++ b/src/openedx_tagging/tasks.py
@@ -17,13 +17,7 @@ def _emit_content_object_associations_changed_for_object_ids(object_ids: Iterabl
     Emit CONTENT_OBJECT_ASSOCIATIONS_CHANGED once for each distinct object ID.
     """
     emitted_events = 0
-    seen_object_ids: set[str] = set()
-
-    for object_id in object_ids:
-        if object_id in seen_object_ids:
-            continue
-        seen_object_ids.add(object_id)
-
+    for object_id in set(object_ids):
         # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
         # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
@@ -40,7 +34,7 @@ def _emit_content_object_associations_changed_for_object_ids(object_ids: Iterabl
 def _emit_content_object_associations_changed_for_tag(tag: Tag) -> int:
     """
     Emit CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for each content object linked to this tag
-    via the ObjectTag assciations. This is used to trigger downstream updates
+    via the ObjectTag associations. This is used to trigger downstream updates
     like search index refreshes in Meilisearch.
     """
     object_ids = ObjectTag.objects.filter(tag=tag).values_list("object_id", flat=True).distinct()

--- a/src/openedx_tagging/tasks.py
+++ b/src/openedx_tagging/tasks.py
@@ -1,6 +1,7 @@
 """Celery tasks for openedx_tagging."""
 
 import logging
+from collections.abc import Iterable
 
 from celery import shared_task  # type: ignore[import]
 from openedx_events.content_authoring.data import ContentObjectChangedData  # type: ignore[import-untyped]
@@ -11,16 +12,18 @@ from openedx_tagging.models.base import ObjectTag, Tag
 logger = logging.getLogger(__name__)
 
 
-def _emit_content_object_associations_changed_for_tag(tag: Tag) -> int:
+def _emit_content_object_associations_changed_for_object_ids(object_ids: Iterable[str]) -> int:
     """
-    Emit CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for each content object linked to this tag
-    via the ObjectTag assciations. This is used to trigger downstream updates
-    like search index refreshes in Meilisearch.
+    Emit CONTENT_OBJECT_ASSOCIATIONS_CHANGED once for each distinct object ID.
     """
-    object_ids = ObjectTag.objects.filter(tag=tag).values_list("object_id", flat=True)
     emitted_events = 0
+    seen_object_ids: set[str] = set()
 
-    for object_id in object_ids.iterator():
+    for object_id in object_ids:
+        if object_id in seen_object_ids:
+            continue
+        seen_object_ids.add(object_id)
+
         # .. event_implemented_name: CONTENT_OBJECT_ASSOCIATIONS_CHANGED
         # .. event_type: org.openedx.content_authoring.content.object.associations.changed.v1
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED.send_event(
@@ -30,6 +33,18 @@ def _emit_content_object_associations_changed_for_tag(tag: Tag) -> int:
             ),
         )
         emitted_events += 1
+
+    return emitted_events
+
+
+def _emit_content_object_associations_changed_for_tag(tag: Tag) -> int:
+    """
+    Emit CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for each content object linked to this tag
+    via the ObjectTag assciations. This is used to trigger downstream updates
+    like search index refreshes in Meilisearch.
+    """
+    object_ids = ObjectTag.objects.filter(tag=tag).values_list("object_id", flat=True).distinct()
+    emitted_events = _emit_content_object_associations_changed_for_object_ids(object_ids.iterator())
 
     logger.info(
         "Tag with id %s was updated. Emitted CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for %s associated objects.",
@@ -57,3 +72,17 @@ def emit_content_object_associations_changed_for_tag_task(tag_id: int) -> int:
         return 0
 
     return _emit_content_object_associations_changed_for_tag(tag)
+
+
+@shared_task
+def emit_content_object_associations_changed_for_object_ids_task(object_ids: list[str]) -> int:
+    """
+    Emit CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for content objects whose
+    tag associations changed because one or more tags were deleted.
+    """
+    emitted_events = _emit_content_object_associations_changed_for_object_ids(object_ids)
+    logger.info(
+        "Deleted tag(s) affected %s associated objects. Emitted CONTENT_OBJECT_ASSOCIATIONS_CHANGED events.",
+        emitted_events,
+    )
+    return emitted_events

--- a/tests/openedx_tagging/test_api.py
+++ b/tests/openedx_tagging/test_api.py
@@ -4,6 +4,7 @@ Test the tagging APIs
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 import ddt  # type: ignore[import]
 import pytest
@@ -741,7 +742,8 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
         # Now delete and disable things:
         disabled_taxonomy.enabled = False
         disabled_taxonomy.save()
-        self.free_text_taxonomy.delete()
+        with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):
+            self.free_text_taxonomy.delete()
         tagging_api.delete_tags_from_taxonomy(self.taxonomy, ["DPANN"], with_subtags=False)
 
         # Now retrieve the tags again:

--- a/tests/openedx_tagging/test_models.py
+++ b/tests/openedx_tagging/test_models.py
@@ -17,7 +17,10 @@ from django.test.testcases import TestCase
 from openedx_tagging import api
 from openedx_tagging.models import LanguageTaxonomy, ObjectTag, Tag, Taxonomy
 from openedx_tagging.models.utils import RESERVED_TAG_CHARS
-from openedx_tagging.tasks import emit_content_object_associations_changed_for_tag_task
+from openedx_tagging.tasks import (
+    emit_content_object_associations_changed_for_object_ids_task,
+    emit_content_object_associations_changed_for_tag_task,
+)
 
 from .utils import pretty_format_tags
 
@@ -1113,6 +1116,70 @@ class TestTagLineage(TestCase):
 
         assert mock_task_delay.call_count == 1
         assert mock_task_delay.call_args[1]['tag_id'] == self.alice.id
+
+    @patch("openedx_tagging.signal_handlers.emit_content_object_associations_changed_for_object_ids_task.delay")
+    def test_delete_updates_search_index(self, mock_task_delay) -> None:
+        """
+        Deleting a tag should enqueue an async task that emits
+        CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for affected objects.
+        """
+        object_id = "content-v1:org+course+run+type@unit+block@125"
+        ObjectTag.objects.create(
+            object_id=object_id,
+            taxonomy=self.bob.taxonomy,
+            tag=self.bob,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.bob.delete()
+
+        assert mock_task_delay.call_count == 1
+        assert mock_task_delay.call_args[1]["object_ids"] == [object_id]
+
+    @patch("openedx_tagging.signal_handlers.emit_content_object_associations_changed_for_object_ids_task.delay")
+    def test_delete_with_descendants_updates_search_index(self, mock_task_delay) -> None:
+        """
+        Deleting a tag should also enqueue updates for any deleted descendants.
+        """
+        alice_object_id = "content-v1:org+course+run+type@unit+block@126"
+        delta_object_id = "content-v1:org+course+run+type@unit+block@127"
+        ObjectTag.objects.create(
+            object_id=alice_object_id,
+            taxonomy=self.alice.taxonomy,
+            tag=self.alice,
+        )
+        ObjectTag.objects.create(
+            object_id=delta_object_id,
+            taxonomy=self.delta.taxonomy,
+            tag=self.delta,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            api.delete_tags_from_taxonomy(self.alice.taxonomy, ["Alice"], with_subtags=True)
+
+        assert mock_task_delay.call_count == 1
+        assert set(mock_task_delay.call_args.kwargs["object_ids"]) == {
+            alice_object_id,
+            delta_object_id,
+        }
+
+    @patch("openedx_tagging.tasks.CONTENT_OBJECT_ASSOCIATIONS_CHANGED", new_callable=MagicMock)
+    def test_emit_content_object_associations_changed_for_object_ids_task(self, mock_signal) -> None:
+        """Task emits one CONTENT_OBJECT_ASSOCIATIONS_CHANGED event per distinct object."""
+        first_object_id = "content-v1:org+course+run+type@unit+block@123"
+        second_object_id = "content-v1:org+course+run+type@unit+block@124"
+
+        emitted_events = emit_content_object_associations_changed_for_object_ids_task(
+            [first_object_id, second_object_id, first_object_id]
+        )
+
+        assert emitted_events == 2
+        assert mock_signal.send_event.call_count == 2
+        emitted_object_ids = {
+            call.kwargs["content_object"].object_id
+            for call in mock_signal.send_event.call_args_list
+        }
+        assert emitted_object_ids == {first_object_id, second_object_id}
 
     @patch("openedx_tagging.tasks.CONTENT_OBJECT_ASSOCIATIONS_CHANGED", new_callable=MagicMock)
     def test_emit_content_object_associations_changed_for_tag_task(self, mock_signal) -> None:

--- a/tests/openedx_tagging/test_models.py
+++ b/tests/openedx_tagging/test_models.py
@@ -1098,16 +1098,18 @@ class TestTagLineage(TestCase):
         assert self.bob.depth == 1
         assert self.bob.lineage == "Charlie\tBob\t"
 
+    # TODO: The following event-emission tests don't really belong in TestTagLineage.
+    # They should be moved to a separate test_events.py module.
     @patch("openedx_tagging.signal_handlers.emit_content_object_associations_changed_for_tag_task.delay")
     def test_rename_updates_search_index(self, mock_task_delay) -> None:
         """
         Renaming a tag should enqueue an async task that emits
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED events.
         """
-        ObjectTag.objects.create(
+        api.tag_object(
             object_id="content-v1:org+course+run+type@unit+block@123",
             taxonomy=self.alice.taxonomy,
-            tag=self.alice,
+            tags=[self.alice.value],
         )
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -1122,12 +1124,17 @@ class TestTagLineage(TestCase):
         """
         Deleting a tag should enqueue an async task that emits
         CONTENT_OBJECT_ASSOCIATIONS_CHANGED events for affected objects.
+
+        Note: this tests deleting a ``Tag`` (not an ``ObjectTag``). Deleting a
+        ``Tag`` triggers the event here in openedx-learning. Deleting an
+        ``ObjectTag`` (i.e. untagging a content object) triggers the same event
+        in openedx-platform instead, so that case is not tested here.
         """
         object_id = "content-v1:org+course+run+type@unit+block@125"
-        ObjectTag.objects.create(
+        api.tag_object(
             object_id=object_id,
             taxonomy=self.bob.taxonomy,
-            tag=self.bob,
+            tags=[self.bob.value],
         )
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -1143,15 +1150,15 @@ class TestTagLineage(TestCase):
         """
         alice_object_id = "content-v1:org+course+run+type@unit+block@126"
         delta_object_id = "content-v1:org+course+run+type@unit+block@127"
-        ObjectTag.objects.create(
+        api.tag_object(
             object_id=alice_object_id,
             taxonomy=self.alice.taxonomy,
-            tag=self.alice,
+            tags=[self.alice.value],
         )
-        ObjectTag.objects.create(
+        api.tag_object(
             object_id=delta_object_id,
             taxonomy=self.delta.taxonomy,
-            tag=self.delta,
+            tags=[self.delta.value],
         )
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -1186,15 +1193,15 @@ class TestTagLineage(TestCase):
         """Task emits one CONTENT_OBJECT_ASSOCIATIONS_CHANGED event per associated object."""
         first_object_id = "content-v1:org+course+run+type@unit+block@123"
         second_object_id = "content-v1:org+course+run+type@unit+block@124"
-        ObjectTag.objects.create(
+        api.tag_object(
             object_id=first_object_id,
             taxonomy=self.alice.taxonomy,
-            tag=self.alice,
+            tags=[self.alice.value],
         )
-        ObjectTag.objects.create(
+        api.tag_object(
             object_id=second_object_id,
             taxonomy=self.alice.taxonomy,
-            tag=self.alice,
+            tags=[self.alice.value],
         )
 
         emitted_events = emit_content_object_associations_changed_for_tag_task(self.alice.id)

--- a/tests/openedx_tagging/test_models.py
+++ b/tests/openedx_tagging/test_models.py
@@ -4,6 +4,7 @@ Test the tagging base models
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import ddt  # type: ignore[import]
@@ -17,6 +18,7 @@ from django.test.testcases import TestCase
 from openedx_tagging import api
 from openedx_tagging.models import LanguageTaxonomy, ObjectTag, Tag, Taxonomy
 from openedx_tagging.models.utils import RESERVED_TAG_CHARS
+from openedx_tagging.signal_handlers import _is_explicit_tag_delete
 from openedx_tagging.tasks import (
     emit_content_object_associations_changed_for_object_ids_task,
     emit_content_object_associations_changed_for_tag_task,
@@ -666,10 +668,20 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
         self.object_tag.save()
         assert self.object_tag.export_id == self.taxonomy.export_id
 
-        # But if the taxonomy is deleted, then the object_tag's export_id reverts to our cached export_id
-        self.taxonomy.delete()
+        # But if the taxonomy is deleted, then the object_tag's export_id reverts to our cached export_id.
+        # Patch explicit-delete detection because this test is about ObjectTag fallback behavior,
+        # not tag deletion event-origins.
+        with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):
+            self.taxonomy.delete()
         self.object_tag.refresh_from_db()
         assert self.object_tag.export_id == "another-taxonomy"
+
+    def test_is_explicit_tag_delete_raises_for_unexpected_origin_type(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Expected origin to be Tag, QuerySet\[Tag\], or None; got Taxonomy",
+        ):
+            _is_explicit_tag_delete(instance=self.tag, origin=cast(Any, self.taxonomy), using="default")
 
     def test_object_tag_value(self):
         # ObjectTag's value defaults to its tag's value
@@ -827,8 +839,11 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
             (self.bacteria.value, True),  # <--- deleted! But the value is preserved.
         ]
 
-        # Then delete the whole free text taxonomy
-        self.free_text_taxonomy.delete()
+        # Then delete the whole free text taxonomy. 
+        # Patch explicit-delete detection because this
+        # test validates ObjectTag deleted-state behavior, not tag deletion event-origins.
+        with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):
+            self.free_text_taxonomy.delete()
 
         assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id, include_deleted=True)] == [
             ("bar", True),  # <--- Deleted, but the value is preserved

--- a/tests/openedx_tagging/test_models.py
+++ b/tests/openedx_tagging/test_models.py
@@ -839,7 +839,7 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
             (self.bacteria.value, True),  # <--- deleted! But the value is preserved.
         ]
 
-        # Then delete the whole free text taxonomy. 
+        # Then delete the whole free text taxonomy.
         # Patch explicit-delete detection because this
         # test validates ObjectTag deleted-state behavior, not tag deletion event-origins.
         with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):


### PR DESCRIPTION
## Description
This PR in conjunction with the openedx-platform PR (https://github.com/openedx/openedx-platform/pull/38477) is the backend component for https://github.com/openedx/modular-learning/issues/260. This PR ensures that when a tag and its descendants are deleted that CONTENT_OBJECT_ASSOCIATIONS_CHANGED events take place for each associated object with no duplicates. The openedx-platform PR ensures that once those events happen, the entire search document is replaced for the relevant content.

*Goal*:
When a Course Author deletes a tag that is associated to Library content, they should be able to return to the Library page and not see those tags in the tag search filter.

## Supporting information
Github Issue: https://github.com/openedx/modular-learning/issues/260

## Testing instructions
Note: This cannot be tested without the code from the following PRs in place:
- https://github.com/openedx/frontend-app-authoring/pull/3035
- https://github.com/openedx/openedx-platform/pull/38477
1. Go to Taxonomies and select a taxonomy
2. Add new tags to this taxonomy that you plan to delete. (I have been adding a subtag (e.g. Wind1) with 2 sibbling children (W1.1 and W1.2) for my testing.)
3. Go to a Library and create 2 new pieces of content.
4. For one piece of content, associate the parent subtag (e.g. Wind1) and click Save.
5. For the other piece of content, associate a child (e.g. W1.2) and click Save.
6. Click on the tag search filter button and note that Wind1 and W1.2 appear in the tag search filter.
7. Return to the taxonomy and delete the subtag Wind1.
8. It should disappear from the taxonomy and a toast should display indicating what was deleted.
9. Go back to the Library and refresh the page in the browser.
10. The pieces of content you previously associated those tags to should now display that 0 tags are associated to them.
11. Click on the tag search filter button and note that Wind1 and W1.2 no longer appear in the tag search filter.

## Deadline

This is for our Verawood code cut stretch goal.

## Other information
While this code requires other PRs in place to be able to test, I believe it can be safely merged without them.