### PR TITLE
fix: Remove TypeError in favor of pass through for unit tests

### DIFF
--- a/src/openedx_core/__init__.py
+++ b/src/openedx_core/__init__.py
@@ -6,4 +6,4 @@ The public APIs belong to the specific apps (openedx_content, openedx_tagging, e
 """
 
 # The version for the entire repository
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/src/openedx_tagging/signal_handlers.py
+++ b/src/openedx_tagging/signal_handlers.py
@@ -34,12 +34,10 @@ def _is_explicit_tag_delete(
     if isinstance(origin, Tag):
         return origin.pk == instance.pk
 
-    # Fail fast if origin has an unexpected type so callsites don't silently
-    # skip event emission logic.
-    if not isinstance(origin, QuerySet):
-        raise TypeError(f"Expected origin to be Tag, QuerySet[Tag], or None; got {type(origin).__name__}")
-    if origin.model is not Tag:
-        raise TypeError(f"Expected origin queryset model Tag; got {origin.model.__name__}")
+    # This is needed to prevent unit test failures where this is called when origin
+    # is not a Tag or QuerySet.
+    if not isinstance(origin, QuerySet) or origin.model is not Tag:
+        return False
 
     # Check if this instance is in the set of explicitly-targeted tags. If not, it's being deleted
     # as a CASCADE side-effect, so it's not explicit.

--- a/tests/openedx_tagging/test_api.py
+++ b/tests/openedx_tagging/test_api.py
@@ -4,7 +4,6 @@ Test the tagging APIs
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
 
 import ddt  # type: ignore[import]
 import pytest
@@ -742,8 +741,7 @@ class TestApiTagging(TestTagTaxonomyMixin, TestCase):
         # Now delete and disable things:
         disabled_taxonomy.enabled = False
         disabled_taxonomy.save()
-        with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):
-            self.free_text_taxonomy.delete()
+        self.free_text_taxonomy.delete()
         tagging_api.delete_tags_from_taxonomy(self.taxonomy, ["DPANN"], with_subtags=False)
 
         # Now retrieve the tags again:

--- a/tests/openedx_tagging/test_models.py
+++ b/tests/openedx_tagging/test_models.py
@@ -4,7 +4,6 @@ Test the tagging base models
 
 from __future__ import annotations
 
-from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import ddt  # type: ignore[import]
@@ -668,20 +667,17 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
         self.object_tag.save()
         assert self.object_tag.export_id == self.taxonomy.export_id
 
-        # But if the taxonomy is deleted, then the object_tag's export_id reverts to our cached export_id.
-        # Patch explicit-delete detection because this test is about ObjectTag fallback behavior,
-        # not tag deletion event-origins.
-        with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):
-            self.taxonomy.delete()
+        # But if the taxonomy is deleted, then the object_tag's export_id reverts to our cached export_id
+        self.taxonomy.delete()
         self.object_tag.refresh_from_db()
         assert self.object_tag.export_id == "another-taxonomy"
 
-    def test_is_explicit_tag_delete_raises_for_unexpected_origin_type(self):
-        with pytest.raises(
-            TypeError,
-            match=r"Expected origin to be Tag, QuerySet\[Tag\], or None; got Taxonomy",
-        ):
-            _is_explicit_tag_delete(instance=self.tag, origin=cast(Any, self.taxonomy), using="default")
+    def test_is_explicit_tag_delete_returns_false_for_unexpected_origin_type(self):
+        assert _is_explicit_tag_delete(
+            instance=self.tag,
+            origin=self.taxonomy,
+            using="default",
+        ) is False
 
     def test_object_tag_value(self):
         # ObjectTag's value defaults to its tag's value
@@ -839,11 +835,8 @@ class TestObjectTag(TestTagTaxonomyMixin, TestCase):
             (self.bacteria.value, True),  # <--- deleted! But the value is preserved.
         ]
 
-        # Then delete the whole free text taxonomy.
-        # Patch explicit-delete detection because this
-        # test validates ObjectTag deleted-state behavior, not tag deletion event-origins.
-        with patch("openedx_tagging.signal_handlers._is_explicit_tag_delete", return_value=False):
-            self.free_text_taxonomy.delete()
+        # Then delete the whole free text taxonomy
+        self.free_text_taxonomy.delete()
 
         assert [(t.value, t.is_deleted) for t in api.get_object_tags(object_id, include_deleted=True)] == [
             ("bar", True),  # <--- Deleted, but the value is preserved


### PR DESCRIPTION
To address
```
FAILED cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py::ClipboardPasteTestCase::test_copy_and_paste_unit_with_tags - TypeError: Expected origin to be Tag, QuerySet[Tag], or None; got Taxonomy
```