### PR TITLE
fix: don't allow publishing within a draft change log context

### DIFF
--- a/src/openedx_content/applets/publishing/api.py
+++ b/src/openedx_content/applets/publishing/api.py
@@ -475,7 +475,9 @@ def publish_from_drafts(
     of the Drafts that are passed in.
     """
     if DraftChangeLogContext.get_active_draft_change_log(learning_package_id) is not None:
-        raise ValidationError("Cannot publish while in bulk_draft_changes_for().")
+        raise ValidationError(
+            f"Cannot publish learning package {learning_package_id} while in bulk_draft_changes_for()."
+        )
     if published_at is None:
         published_at = datetime.now(tz=timezone.utc)
 

--- a/src/openedx_content/applets/publishing/api.py
+++ b/src/openedx_content/applets/publishing/api.py
@@ -474,6 +474,8 @@ def publish_from_drafts(
     By default, this will also publish all dependencies (e.g. unpinned children)
     of the Drafts that are passed in.
     """
+    if DraftChangeLogContext.get_active_draft_change_log(learning_package_id) is not None:
+        raise ValidationError("Cannot publish while in bulk_draft_changes_for().")
     if published_at is None:
         published_at = datetime.now(tz=timezone.utc)
 

--- a/tests/openedx_content/applets/publishing/test_api.py
+++ b/tests/openedx_content/applets/publishing/test_api.py
@@ -2533,3 +2533,39 @@ class CrossEntityValidationTestCase(TransactionTestCase):
                 created_by=None,
                 dependencies=[entity_in_lp2.id],
             )
+
+    def test_publish_functions_rejected_inside_bulk_draft_changes_for(self) -> None:
+        """
+        publish_all_drafts() and publish_from_drafts() must not be callable
+        from within a bulk_draft_changes_for() context.
+
+        bulk_draft_changes_for() opens a DraftChangeLog for accumulating draft
+        edits; running a publish inside it mixes draft-change bookkeeping with
+        publish bookkeeping in the same atomic block, which corrupts the
+        ordering of DraftChangeLog vs. PublishLog records and can leave Drafts
+        and Published rows out of sync if the outer context later raises.
+        """
+        entity = publishing_api.create_publishable_entity(
+            self.learning_package_1.id,
+            "entity_for_bulk_publish_check",
+            created=self.now,
+            created_by=None,
+        )
+        publishing_api.create_publishable_entity_version(
+            entity.id,
+            version_num=1,
+            title="Entity v1",
+            created=self.now,
+            created_by=None,
+        )
+
+        with pytest.raises(ValidationError, match="Cannot publish while in bulk_draft_changes_for()."):
+            with publishing_api.bulk_draft_changes_for(self.learning_package_1.id):
+                publishing_api.publish_all_drafts(self.learning_package_1.id)
+
+        with pytest.raises(ValidationError, match="Cannot publish while in bulk_draft_changes_for()."):
+            with publishing_api.bulk_draft_changes_for(self.learning_package_1.id):
+                publishing_api.publish_from_drafts(
+                    self.learning_package_1.id,
+                    Draft.objects.filter(entity__learning_package_id=self.learning_package_1.id),
+                )

--- a/tests/openedx_content/applets/publishing/test_api.py
+++ b/tests/openedx_content/applets/publishing/test_api.py
@@ -2545,6 +2545,7 @@ class CrossEntityValidationTestCase(TransactionTestCase):
         ordering of DraftChangeLog vs. PublishLog records and can leave Drafts
         and Published rows out of sync if the outer context later raises.
         """
+        lp1_id = self.learning_package_1.id
         entity = publishing_api.create_publishable_entity(
             self.learning_package_1.id,
             "entity_for_bulk_publish_check",
@@ -2559,13 +2560,20 @@ class CrossEntityValidationTestCase(TransactionTestCase):
             created_by=None,
         )
 
-        with pytest.raises(ValidationError, match="Cannot publish while in bulk_draft_changes_for()."):
-            with publishing_api.bulk_draft_changes_for(self.learning_package_1.id):
-                publishing_api.publish_all_drafts(self.learning_package_1.id)
+        with pytest.raises(
+            ValidationError,
+            match=f"Cannot publish learning package {lp1_id} while in bulk_draft_changes_for()."
+        ):
+            with publishing_api.bulk_draft_changes_for(lp1_id):
+                publishing_api.publish_all_drafts(lp1_id)
 
-        with pytest.raises(ValidationError, match="Cannot publish while in bulk_draft_changes_for()."):
-            with publishing_api.bulk_draft_changes_for(self.learning_package_1.id):
-                publishing_api.publish_from_drafts(
-                    self.learning_package_1.id,
-                    Draft.objects.filter(entity__learning_package_id=self.learning_package_1.id),
-                )
+        with pytest.raises(
+            ValidationError,
+            match=f"Cannot publish learning package {lp1_id} while in bulk_draft_changes_for()."
+        ):
+            with publishing_api.bulk_draft_changes_for(lp1_id):
+                publishing_api.publish_from_drafts(lp1_id, Draft.objects.filter(entity__learning_package_id=lp1_id))
+
+        # But we CAN publish if the bulk_draft_changes_for is a different learning package:
+        with publishing_api.bulk_draft_changes_for(self.learning_package_2.id):
+            publishing_api.publish_all_drafts(lp1_id)


### PR DESCRIPTION
I'm not sure if this is best described as a `fix:` or a `feat!:`, but I'm opening this PR so we can consider re-landing this additional validation.

This PR disallows any publish APIs within a bulk draft changes context.

For the record, before we merge it, we have to refactor openedx-platform's modulestore_migrator: https://github.com/openedx/openedx-platform/pull/38508

Part of https://github.com/openedx/openedx-core/issues/463 . Originally merged as part of https://github.com/openedx/openedx-core/pull/521 but later reverted in https://github.com/openedx/openedx-core/pull/574 after we discovered the modulestore_migrator issue.

### Motivation

Allowing publishes within a draft change context risks publishing snapshots that are in an intermediate draft state. A `DraftChangeLog` is designed to collapse repeated edits to the same entity into a single record (old→final) at exit — see `_add_to_existing_draft_change_log`. If you do `set_draft_version(A, v2); publish_all_drafts(...); set_draft_version(A, v3)` inside the same context, `Published.version` ends up at v2 (a transient mid-bulk state), while the `DraftChangeLog` records A: v1 → v3. The publish captures a state that was never a settled state of the bulk change. (particularly relevant with events that get emitted, as published events would be emitted before draft events.)

Furthermore, in the specific case of modulestore_migrator it currently does something we definitely don't want: it groups all the migrated drafts into a single draft change log, but it creates many separate publish logs - one for each imported component and container.

### Alternative

An alternative validation could be to allow publishes within a bulk draft changes context, but then disallow any further draft changes to those entities which are published. I don't really like this approach though as it requires a lot more bookkeeping. It would allow us to keep the modulestore_migrator code unchanged, but I think that's not good because it still has this problematic creation of many publish logs.
