### PR TITLE
build: Adjust docs/conf.py to fix RTD build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,17 +37,16 @@ sys.path.append(REPO_ROOT)
 
 VERSION = get_version('../src/openedx_core', '__init__.py')
 
-# Configure Django for autodoc usage
-os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
-django_setup()
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../src'))
+
+# Configure Django for autodoc usage
+os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
+django_setup()
 
 # -- General configuration ------------------------------------------------
 

--- a/src/openedx_content/applets/containers/api.py
+++ b/src/openedx_content/applets/containers/api.py
@@ -885,6 +885,7 @@ def get_descendant_component_entity_ids(container: Container) -> list[int]:
     automatically because ``get_entities_in_container`` omits them.
 
     Edge cases:
+
     - A container whose draft was soft-deleted has no children to traverse and
       contributes no entity IDs.
     - An entity that appears as a child of multiple containers is deduplicated

--- a/src/openedx_content/applets/publishing/api.py
+++ b/src/openedx_content/applets/publishing/api.py
@@ -625,6 +625,7 @@ def get_entity_draft_history(
     ordered from most recent to oldest.
 
     Edge cases:
+
     - Never published, no versions: returns an empty queryset.
     - Never published, has versions: returns all DraftChangeLogRecords.
     - No changes since the last publish: returns an empty queryset.
@@ -691,6 +692,7 @@ def get_entity_publish_history(
     Return all PublishLogRecords for a PublishableEntity, ordered most recent first.
 
     Edge cases:
+
     - Never published: returns an empty queryset.
     - Soft-delete published (new_version=None): the record is included with
       old_version pointing to the last published version and new_version=None,
@@ -735,6 +737,7 @@ def get_entity_publish_history_entries(
     joins.
 
     Edge cases:
+
     - Each publish group is independent: only the DraftChangeLogRecords that
       belong to the requested publish_log_uuid are returned; changes attributed
       to other publish groups are excluded.
@@ -831,6 +834,7 @@ def get_entity_version_contributors(
     record whose old_version falls before old_version_num is excluded.
 
     Edge cases:
+
     - If no DraftChangeLogRecords fall in the range, returns an empty queryset.
     - Records with changed_by=None (system changes with no associated user) are
       always excluded.

--- a/src/openedx_content/applets/publishing/models/draft_log.py
+++ b/src/openedx_content/applets/publishing/models/draft_log.py
@@ -338,6 +338,7 @@ class DraftSideEffect(models.Model):
 
     Scenario 1: In the a bulk_draft_changes_for context, we edit C1 so that the
     draft version of C1 is now C1.v2. Result:
+
     - a DraftChangeLogRecord is created for C1.v1 -> C1.v2
     - a DraftChangeLogRecord is created for U1.v1 -> U1.v1
     - a DraftSideEffect is created with cause (C1.v1 -> C1.v2) and effect
@@ -350,6 +351,7 @@ class DraftSideEffect(models.Model):
     draft version of C1 is now C1.v2. In the same context, we edit U1's metadata
     so that the draft version of U1 is now U1.v2. U1.v2 still lists C1 as a
     child entity. Result:
+
     - a DraftChangeLogRecord is created for C1.v1 -> C1.v2
     - a DraftChangeLogRecord is created for U1.v1 -> U1.v2
     - a DraftSideEffect is created with cause (C1.v1 -> C1.v2) and effect
@@ -358,6 +360,7 @@ class DraftSideEffect(models.Model):
     Scenario 3: In a bulk_draft_changes_for context, we edit C1 so that the
     draft version of C1 is now C1.v2. In the same context, we edit U1's list of
     children so that C1 is no longer a child of U1.v2. Result:
+
     - a DraftChangeLogRecord is created for C1.v1 -> C1.v2
     - a DraftChangeLogRecord is created for U1.v1 -> U1.v2
     - no SideEffect is created, since changing C1 does not have an impact on the

--- a/src/openedx_content/applets/publishing/models/publishable_entity.py
+++ b/src/openedx_content/applets/publishing/models/publishable_entity.py
@@ -83,11 +83,11 @@ class PublishableEntity(models.Model):
     model instead of storing them in those other models? Two reasons:
 
     * Published things need to have the right identifiers so they can be used
-    throughout the system, and the UUID is serving the role of ISBN in physical
-    book publishing.
+      throughout the system, and the UUID is serving the role of ISBN in physical
+      book publishing.
     * We want to be able to enforce the idea that "entity_ref" is locally unique across
-    all PublishableEntities within a given LearningPackage. Component and Unit
-    can't do that without a shared model.
+      all PublishableEntities within a given LearningPackage. Component and Unit
+      can't do that without a shared model.
 
     That being said, models that build on PublishableEntity are free to add
     their own identifiers if it's useful to do so.


### PR DESCRIPTION
See https://daniel.feldroy.com/posts/2023-01-configuring-sphinx-auto-doc-with-django for two issues - path needed to be specified, and DJANGO_SETTINGS_MODULE needs to be set _after_ the path is fixed.

# [THE DOC BUILD... IT LIVES](https://openedx-core--591.org.readthedocs.build/en/591/)