### PR TITLE
fix: don't emit COLLECTION_CHANGED when entities restored into deleted collections

### DIFF
--- a/src/openedx_content/applets/collections/tasks.py
+++ b/src/openedx_content/applets/collections/tasks.py
@@ -36,6 +36,7 @@ def emit_collections_changed_for_entity_changes_task(
 
     affected_cpes = (
         CollectionPublishableEntity.objects.filter(entity_id__in=all_entity_ids)
+        .filter(collection__enabled=True)  # Don't send events for soft-deleted collections
         .select_related("collection__learning_package")
         .order_by("collection_id", "entity_id")
     )

--- a/tests/openedx_content/applets/collections/test_signals.py
+++ b/tests/openedx_content/applets/collections/test_signals.py
@@ -534,6 +534,34 @@ def test_entity_draft_restored_multiple_collections(lp1: LearningPackage) -> Non
     )
 
 
+def test_entity_draft_restored_skips_soft_deleted_collections(lp1: LearningPackage) -> None:
+    """
+    Test that COLLECTION_CHANGED is NOT emitted for soft-deleted collections
+    when an entity's draft is restored, even if the entity is still a member
+    of those collections.
+    """
+    col1 = api.create_collection(lp1.id, "col1", title="Collection 1", created_by=None)
+    api.create_collection(lp1.id, "col2-deleted", title="Collection 2", created_by=None)
+    entity = _create_entity_with_version(lp1.id, "entity1")
+    api.add_to_collection(lp1.id, "col1", PublishableEntity.objects.filter(id=entity.id))
+    api.add_to_collection(lp1.id, "col2-deleted", PublishableEntity.objects.filter(id=entity.id))
+    api.soft_delete_draft(entity.id)
+    api.delete_collection(lp1.id, "col2-deleted")  # soft-delete col2
+
+    with capture_events(signals=[COLLECTION_CHANGED], expected_count=1) as captured:
+        api.create_publishable_entity_version(
+            entity.id, version_num=2, title="entity1 v2", created=now_time, created_by=None
+        )
+
+    # Only the still-enabled collection (col1) should receive an event.
+    event = captured[0]
+    assert event.kwargs["change"] == CollectionChangeData(
+        collection_id=col1.id,
+        collection_code="col1",
+        entities_added=[entity.id],
+    )
+
+
 def test_entity_draft_restored_aborted(lp1: LearningPackage) -> None:
     """
     Test that no COLLECTION_CHANGED is emitted when the


### PR DESCRIPTION
While working on optimizing the modulestore migrator I noticed an edge case:


1. Create a container, add it to a collection
2. Delete the container
3. [Soft] delete the collection
4. Restore the container

Unexpectedly, `COLLECTION_CHANGED` events are emitted for the deleted collection.

This fixes the bug, and adds a test.

This bug is a pretty obscure case, but it would still be good to include it on our Verawood branch at some point.