### PR TITLE
fix: allow restoring content with blank titles

### DIFF
--- a/src/openedx_content/applets/backup_restore/serializers.py
+++ b/src/openedx_content/applets/backup_restore/serializers.py
@@ -63,7 +63,9 @@ class EntityVersionSerializer(serializers.Serializer):  # pylint: disable=abstra
     """
     Serializer for publishable entity versions.
     """
-    title = serializers.CharField(required=True)
+    # We allow_blank because empty unit titles are legal and common.
+    title = serializers.CharField(required=True, allow_blank=True)
+
     created = serializers.DateTimeField(required=True, default_timezone=timezone.utc)
     version_num = serializers.IntegerField(required=True)
 

--- a/tests/openedx_content/applets/backup_restore/fixtures/library_backup/entities/unit1-b7eafb.toml
+++ b/tests/openedx_content/applets/backup_restore/fixtures/library_backup/entities/unit1-b7eafb.toml
@@ -14,7 +14,7 @@ version_num = 2
 # ### Versions
 
 [[version]]
-title = ""
+title = ""  # Intentionally blank in order to test that empty Unit names work
 version_num = 2
 
 [version.container]

--- a/tests/openedx_content/applets/backup_restore/fixtures/library_backup/entities/unit1-b7eafb.toml
+++ b/tests/openedx_content/applets/backup_restore/fixtures/library_backup/entities/unit1-b7eafb.toml
@@ -14,7 +14,7 @@ version_num = 2
 # ### Versions
 
 [[version]]
-title = "Unit1"
+title = ""
 version_num = 2
 
 [version.container]

--- a/tests/openedx_content/applets/backup_restore/test_restore.py
+++ b/tests/openedx_content/applets/backup_restore/test_restore.py
@@ -342,6 +342,29 @@ class RestoreLearningPackageTest(RestoreTestCase):
         expected_error = "Errors encountered during restore:\npackage.toml meta section: {'non_field_errors': [Er"
         assert expected_error in log_content
 
+    def test_restore_with_blank_unit_title(self):
+        """
+        Restoring should succeed when a container version has a blank title.
+
+        Blank titles are legal and common -- content imported from courses
+        (e.g. via the modulestore migrator) frequently has untitled units, and
+        such content can be backed up. Restoring that same archive must work.
+
+        The ``library_backup`` fixture's ``unit1`` deliberately has a blank
+        title to exercise this path.
+        """
+        result = LearningPackageUnzipper(self.zip_file, package_ref="lib-xx:WGU:LIB_C001").load()
+
+        assert result["status"] == "success", f"Restore failed: {result['log_file_error']}"
+        assert result["log_file_error"] is None
+
+        lp = publishing_api.LearningPackage.objects.get(package_ref="lib-xx:WGU:LIB_C001")
+        unit = containers_api.get_containers(learning_package_id=lp.id).get(
+            publishable_entity__entity_ref="unit1-b7eafb"
+        )
+        draft_version = publishing_api.get_draft_version(unit.publishable_entity.id)
+        assert draft_version.title == ""
+
     def test_success_metadata_using_user_context(self):
         """Test that metadata is correctly extracted from learning_package.toml."""
         restore_result = LearningPackageUnzipper(self.zip_file, user=self.user).load()


### PR DESCRIPTION
## Description

Restoring a library archive failed whenever any unit (or other container/component) version had a blank title. Blank titles are legal (`PublishableEntityVersion.title` is `blank=True`) and common — content imported from courses via the modulestore migrator frequently has untitled units, and such content can be backed up.

The version title round-trips as an empty string, but `EntityVersionSerializer.title` used `CharField(required=True)`, which defaults to `allow_blank=False`, so the empty string failed validation and aborted the whole restore. This sets `allow_blank=True` so blank titles validate.

The `library_backup` test fixture's `unit1` now has a blank title to exercise this path, with a regression test asserting it restores correctly.

## Related issue

Fixes https://github.com/openedx/openedx-platform/issues/38611

## Manual testing instructions

This is the updated library from the test suite:

[fixture-library.zip](https://github.com/user-attachments/files/29214707/fixture-library.zip)

Restore it on master gives:
```
Errors encountered during restore:
entities/unit1-b7eafb.toml: {'title': [ErrorDetail(string='This field may not be blank.', code='blank')]}
entities/unit1-b7eafb.toml: {'title': [ErrorDetail(string='This field may not be blank.', code='blank')]}
```

Restoring it on this PR's sandbox works (TODO need to verify this once the sandbox is up!)

## Other notes

- This relaxes `allow_blank` only on entity *version* titles (units, sections, subsections, components). Learning package and collection titles are unchanged.

## AI

Generated by Claude Opus 4.8 with this prompt:

> issue: Library Restore fails when Unit titles are blank. it is
  both legal and common for people to have untitled content in
  courses. The modulestore migrator can bring this content in from
  courses, and we can export it as a backup archive. Restoring that
  same data should also work.
> context: A "library" is is a bundle of reusable learning content.
  You will not actually see the term "library" in this repo, but you
  will see "LearningPackage", which at this time is 1:1 with
  Library. The src/openedx_content/applets/backup_restore applet is
  resonsible for serializing learning packages to and from ZIP
  archives. The aforementioned "moduelstore migrator" is not
  something you need to worry about--it's a subsystem of
  openedx-platform (the django project which uses this library,
  openedx-core) which transfers content in from our legacy storage
  format into openedx-core-based learning packges, and (as
  mentioned) it supports blank unit titles.
> instructions:
>  * Start in just src/openedx_content. I expect the bug to be in the
  backup_restore applet. it's ok to read src/openedx_django_lib if
  necessary too, but if you find youself needing to read other
  openedx-core code, or other openedx libraries, or the
  openedx-platform (which is where Libraries are defined) then pause
  and talk to me first.
>  * .imporlinter will explain the code structure to you and help you
  avoid unnecessary code walking and test-running
>  * when running python, use the venv at .venv/bin/activate
>  * you can validate changes by running:
>    * pycodestyle src  # basic quality checks, fast
>    * pylint src/<blah>  # slow quality checks; use targeted paths
>    * pytest src/<blah>  # unit tests; use targeted paths
>    * lint-imports  # structural checking
>  * use builtin tools whenever possible

I reviewed the code and had it rework the test to be simpler.

## Merge deadline

ASAP. We will want to backport this to Verawood before the release, which is probably next week.